### PR TITLE
Feat/gh78 link real data to project card and add new query to fetch review comments and tasks : Fix #78 #73

### DIFF
--- a/UI_DSM/UI_DSM.Client.Tests/Pages/NormalUser/ProjectPage/NormalProjectPageTestFixture.cs
+++ b/UI_DSM/UI_DSM.Client.Tests/Pages/NormalUser/ProjectPage/NormalProjectPageTestFixture.cs
@@ -23,6 +23,7 @@ namespace UI_DSM.Client.Tests.Pages.NormalUser.ProjectPage
 
     using UI_DSM.Client.Components.NormalUser.ProjectReview;
     using UI_DSM.Client.Services.Administration.ProjectService;
+    using UI_DSM.Client.Services.ReviewService;
     using UI_DSM.Client.Tests.Helpers;
     using UI_DSM.Shared.Models;
     using UI_DSM.Client.ViewModels.Pages.NormalUser.ProjectPage;
@@ -38,6 +39,7 @@ namespace UI_DSM.Client.Tests.Pages.NormalUser.ProjectPage
         private INormalProjectPageViewModel viewModel;
         private IProjectReviewViewModel projectReviewViewModel;
         private Mock<IProjectService> projectService;
+        private Mock<IReviewService> reviewService;
 
         [SetUp]
         public void Setup()
@@ -45,7 +47,8 @@ namespace UI_DSM.Client.Tests.Pages.NormalUser.ProjectPage
             this.context = new TestContext();
             this.projectReviewViewModel = new ProjectReviewViewModel(null);
             this.projectService = new Mock<IProjectService>();
-            this.viewModel = new NormalProjectPageViewModel(this.projectService.Object, this.projectReviewViewModel);
+            this.reviewService = new Mock<IReviewService>();
+            this.viewModel = new NormalProjectPageViewModel(this.projectService.Object, this.reviewService.Object, this.projectReviewViewModel);
             this.context.Services.AddSingleton(this.viewModel);
         }
 

--- a/UI_DSM/UI_DSM.Client.Tests/Services/Administration/ProjectService/ProjectServiceTestFixture.cs
+++ b/UI_DSM/UI_DSM.Client.Tests/Services/Administration/ProjectService/ProjectServiceTestFixture.cs
@@ -191,10 +191,10 @@ namespace UI_DSM.Client.Tests.Services.Administration.ProjectService
             var httpResponse = new HttpResponseMessage();
             httpResponse.StatusCode = HttpStatusCode.BadRequest;
 
-            var request = this.httpMessageHandler.When(HttpMethod.Get, "/Project/GetOpenTasksAndComments");
+            var request = this.httpMessageHandler.When(HttpMethod.Get, "/Project/OpenTasksAndComments");
             request.Respond(_ => httpResponse);
 
-            Assert.That(async () => await this.service.GetOpenTasksAndComments(null), Throws.Exception);
+            Assert.That(async () => await this.service.GetOpenTasksAndComments(), Throws.Exception);
 
             httpResponse.StatusCode = HttpStatusCode.OK;
 
@@ -213,7 +213,7 @@ namespace UI_DSM.Client.Tests.Services.Administration.ProjectService
             };
 
             httpResponse.Content = new StringContent(this.jsonService.Serialize(requestResults));
-            Assert.That(await this.service.GetOpenTasksAndComments(guids), Is.EquivalentTo(requestResults));
+            Assert.That(await this.service.GetOpenTasksAndComments(), Is.EquivalentTo(requestResults));
         }
     }
 }

--- a/UI_DSM/UI_DSM.Client.Tests/Services/ReviewService/ReviewServiceTestFixture.cs
+++ b/UI_DSM/UI_DSM.Client.Tests/Services/ReviewService/ReviewServiceTestFixture.cs
@@ -238,5 +238,38 @@ namespace UI_DSM.Client.Tests.Services.ReviewService
             httpResponse.Content = new StringContent(string.Empty);
             Assert.That(async () => await this.service.UpdateReview(review), Throws.Exception);
         }
+
+        [Test]
+        public async Task VerifyGetOpenTaskAndComments()
+        {
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.StatusCode = HttpStatusCode.BadRequest;
+
+            Project project = new Project(Guid.NewGuid());
+
+            var request = this.httpMessageHandler.When(HttpMethod.Get, $"/Project/{project.Id}/Review/OpenTasksAndComments");
+            request.Respond(_ => httpResponse);
+
+            Assert.That(async () => await this.service.GetOpenTasksAndComments(project.Id), Throws.Exception);
+
+            httpResponse.StatusCode = HttpStatusCode.OK;
+
+            var guids = new List<Guid>
+            {
+                Guid.NewGuid()
+            };
+
+            var requestResults = new Dictionary<Guid, ComputedProjectProperties>
+            {
+                [guids[0]] = new()
+                {
+                    CommentCount = 15,
+                    TaskCount = 12
+                }
+            };
+
+            httpResponse.Content = new StringContent(this.jsonService.Serialize(requestResults));
+            Assert.That(await this.service.GetOpenTasksAndComments(project.Id), Is.EquivalentTo(requestResults));
+        }
     }
 }

--- a/UI_DSM/UI_DSM.Client/Components/App/AppProjectCard/AppProjectCard.razor
+++ b/UI_DSM/UI_DSM.Client/Components/App/AppProjectCard/AppProjectCard.razor
@@ -19,7 +19,7 @@
   </div>
   <div class="app-project-card__footer">
 
-    @if (Tasks > 0)
+    @if (Tasks >= 0)
     {
       <div class="app-project-card__stat">
         <div class="app-project-card__icon">
@@ -32,7 +32,7 @@
       </div>
     }
 
-    @if (Comments > 0)
+    @if (Comments >= 0)
     {
       <div class="app-project-card__stat">
         <div class="app-project-card__icon">

--- a/UI_DSM/UI_DSM.Client/Components/NormalUser/ProjectReview/ProjectReview.razor
+++ b/UI_DSM/UI_DSM.Client/Components/NormalUser/ProjectReview/ProjectReview.razor
@@ -18,7 +18,7 @@
       @foreach (var review in this.ViewModel.Project.Reviews)
 	  {
           <NavLink href=@("/Project/"+this.ViewModel.Project.Id+"/Review/"+review.Id)>
-            <AppProjectCard Title="@review.Title" Created="@review.CreatedOn.ToString()" Tasks="20" Comments="20" />
+                <AppProjectCard Title="@review.Title" Created="@review.CreatedOn.ToString()" Tasks="20" Comments="20" />
           </NavLink>
       }
   </div>

--- a/UI_DSM/UI_DSM.Client/Components/NormalUser/ProjectReview/ProjectReview.razor
+++ b/UI_DSM/UI_DSM.Client/Components/NormalUser/ProjectReview/ProjectReview.razor
@@ -18,7 +18,14 @@
       @foreach (var review in this.ViewModel.Project.Reviews)
 	  {
           <NavLink href=@("/Project/"+this.ViewModel.Project.Id+"/Review/"+review.Id)>
-                <AppProjectCard Title="@review.Title" Created="@review.CreatedOn.ToString()" Tasks="20" Comments="20" />
+                @if (this.ViewModel.CommentsAndTasks.ContainsKey(review.Id))
+                {
+                   <AppProjectCard Title="@review.Title" Created="@review.CreatedOn.ToString()" Tasks="@this.ViewModel.CommentsAndTasks[review.Id].TaskCount" Comments="@this.ViewModel.CommentsAndTasks[review.Id].CommentCount" />
+                }
+                else
+                {
+                   <AppProjectCard Title="@review.Title" Created="@review.CreatedOn.ToString()" Tasks="-1" Comments="-1" />
+                }
           </NavLink>
       }
   </div>

--- a/UI_DSM/UI_DSM.Client/Pages/Index.razor
+++ b/UI_DSM/UI_DSM.Client/Pages/Index.razor
@@ -10,7 +10,7 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 
-@page "/index"
+@page "/"
 @layout DefaultLayout
 
 <PageTitle>Dashboard | UI-DSM</PageTitle>
@@ -24,7 +24,7 @@
         @foreach (var project in this.ViewModel.AvailableProject.Items)
         {
             <NavLink href=@("/Project/"+project.Id)>
-                <AppProjectCard Title="@project.ProjectName" Created="05-10-2022 18:43" Tasks="20" Comments="20" />
+                <AppProjectCard Title="@project.ProjectName" Created="@project.CreatedOn.ToString()" Tasks="@this.ViewModel.CommentsAndTasks[project.Id].TaskCount" Comments="0" />
             </NavLink>
         }
      </div>

--- a/UI_DSM/UI_DSM.Client/Pages/Index.razor
+++ b/UI_DSM/UI_DSM.Client/Pages/Index.razor
@@ -24,7 +24,14 @@
         @foreach (var project in this.ViewModel.AvailableProject.Items)
         {
             <NavLink href=@("/Project/"+project.Id)>
-                <AppProjectCard Title="@project.ProjectName" Created="@project.CreatedOn.ToString()" Tasks="@this.ViewModel.CommentsAndTasks[project.Id].TaskCount" Comments="0" />
+                @if (this.ViewModel.CommentsAndTasks.ContainsKey(project.Id))
+                {
+                    <AppProjectCard Title="@project.ProjectName" Created="@project.CreatedOn.ToString()" Tasks="@this.ViewModel.CommentsAndTasks[project.Id].TaskCount" Comments="@this.ViewModel.CommentsAndTasks[project.Id].CommentCount" />
+                }
+                else
+                {
+                    <AppProjectCard Title="@project.ProjectName" Created="@project.CreatedOn.ToString()" Tasks="-1" Comments="-1" />
+                }
             </NavLink>
         }
      </div>

--- a/UI_DSM/UI_DSM.Client/Pages/NormalUser/ReviewObjectivePage/ReviewObjectivePage.razor
+++ b/UI_DSM/UI_DSM.Client/Pages/NormalUser/ReviewObjectivePage/ReviewObjectivePage.razor
@@ -12,7 +12,7 @@
 @page "/Project/{ProjectId}/Review/{ReviewId}/ReviewObjective/{ReviewObjectiveId}"
 @layout DefaultLayout
 
-<PageTitle>Objective title | UI-DSM</PageTitle>
+<PageTitle>Review Objective | UI-DSM</PageTitle>
 
 @if (this.ViewModel.ReviewObjectiveTasksViewModel.ReviewObjective == null)
 {

--- a/UI_DSM/UI_DSM.Client/Pages/NormalUser/ReviewPage/ReviewPage.razor
+++ b/UI_DSM/UI_DSM.Client/Pages/NormalUser/ReviewPage/ReviewPage.razor
@@ -12,7 +12,7 @@
 @page "/Project/{ProjectId}/Review/{ReviewId}"
 @layout DefaultLayout
 
-<PageTitle>Project | UI-DSM</PageTitle>
+<PageTitle>Project Review | UI-DSM</PageTitle>
 
 @if (this.ViewModel.ReviewObjectiveViewModel.Review == null)
 {

--- a/UI_DSM/UI_DSM.Client/Pages/ProjectsPage/ProjectsPage.razor
+++ b/UI_DSM/UI_DSM.Client/Pages/ProjectsPage/ProjectsPage.razor
@@ -10,7 +10,7 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 
-@page "/"
+@page "/proj"
 @layout DefaultLayout
 
 <PageTitle>Projects | UI-DSM</PageTitle>

--- a/UI_DSM/UI_DSM.Client/Pages/ProjectsPage/ProjectsPage.razor
+++ b/UI_DSM/UI_DSM.Client/Pages/ProjectsPage/ProjectsPage.razor
@@ -10,7 +10,7 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 
-@page "/proj"
+@page "/projects"
 @layout DefaultLayout
 
 <PageTitle>Projects | UI-DSM</PageTitle>

--- a/UI_DSM/UI_DSM.Client/Services/Administration/ProjectService/IProjectService.cs
+++ b/UI_DSM/UI_DSM.Client/Services/Administration/ProjectService/IProjectService.cs
@@ -61,8 +61,7 @@ namespace UI_DSM.Client.Services.Administration.ProjectService
         ///     Gets, for all <see cref="Project" />, the number of open <see cref="ReviewTask" /> and <see cref="Comment" />
         ///     related to the <see cref="Project" />
         /// </summary>
-        /// <param name="projectsId">A collection of <see cref="Guid" /></param>
         /// <returns>A <see cref="Task" /> with a <see cref="Dictionary{Guid, ComputedProjectProperties}" /></returns>
-        Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments(IEnumerable<Guid> projectsId);
+        Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments();
     }
 }

--- a/UI_DSM/UI_DSM.Client/Services/Administration/ProjectService/ProjectService.cs
+++ b/UI_DSM/UI_DSM.Client/Services/Administration/ProjectService/ProjectService.cs
@@ -136,25 +136,15 @@ namespace UI_DSM.Client.Services.Administration.ProjectService
         ///     Gets, for all <see cref="Project" />, the number of open <see cref="ReviewTask" /> and <see cref="Comment" />
         ///     related to the <see cref="Project" />
         /// </summary>
-        /// <param name="projectsId">A collection of <see cref="Guid" /></param>
         /// <returns>A <see cref="Task" /> with a <see cref="Dictionary{Guid, ComputedProjectProperties}" /></returns>
-        public async Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments(IEnumerable<Guid> projectsId)
+        public async Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments()
         {
-            var content = this.jsonService.Serialize(projectsId);
-            var body = new StringContent(content, Encoding.UTF8, "application/json");
-
-            var request = new HttpRequestMessage(HttpMethod.Get, $"{this.MainRoute}/GetOpenTasksAndComments")
-            {
-                Content = body
-            };
-
-            var response = await this.HttpClient.SendAsync(request);
+            var response = await this.HttpClient.GetAsync($"{this.MainRoute}/OpenTasksAndComments");
 
             if (!response.IsSuccessStatusCode)
             {
                 throw new HttpRequestException(response.ReasonPhrase);
             }
-
             return this.jsonService.Deserialize<Dictionary<Guid, ComputedProjectProperties>>(await response.Content.ReadAsStreamAsync());
         }
     }

--- a/UI_DSM/UI_DSM.Client/Services/ReviewService/IReviewService.cs
+++ b/UI_DSM/UI_DSM.Client/Services/ReviewService/IReviewService.cs
@@ -60,5 +60,12 @@ namespace UI_DSM.Client.Services.ReviewService
         /// <param name="review">The <see cref="Review" /> to delete</param>
         /// <returns>A <see cref="Task" /> with the <see cref="RequestResponseDto" /></returns>
         Task<RequestResponseDto> DeleteReview(Review review);
+
+        /// <summary>
+        ///     Gets, for a <see cref="Review" />, the number of open <see cref="ReviewTask" /> and <see cref="Comment" />
+        ///     related to the <see cref="Review" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /> with a <see cref="Dictionary{Guid, ComputedProjectProperties}" /></returns>
+        Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments(Guid projectId);
     }
 }

--- a/UI_DSM/UI_DSM.Client/Services/ReviewService/ReviewService.cs
+++ b/UI_DSM/UI_DSM.Client/Services/ReviewService/ReviewService.cs
@@ -134,5 +134,23 @@ namespace UI_DSM.Client.Services.ReviewService
                 throw new HttpRequestException(exception.Message);
             }
         }
+
+        /// <summary>
+        ///     Gets, for all <see cref="Review" />, the number of open <see cref="ReviewTask" /> and <see cref="Comment" />
+        ///     related to the <see cref="Review" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /> with a <see cref="Dictionary{Guid, ComputedProjectProperties}" /></returns>
+        public async Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments(Guid projectId)
+        {
+            this.ComputeMainRoute(projectId);
+            var response = await this.HttpClient.GetAsync($"{this.MainRoute}/OpenTasksAndComments");
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(response.ReasonPhrase);
+            }
+            var content = await response.Content.ReadAsStringAsync();
+            return this.jsonService.Deserialize<Dictionary<Guid, ComputedProjectProperties>>(await response.Content.ReadAsStreamAsync());
+        }
     }
 }

--- a/UI_DSM/UI_DSM.Client/Services/ReviewService/ReviewService.cs
+++ b/UI_DSM/UI_DSM.Client/Services/ReviewService/ReviewService.cs
@@ -149,7 +149,6 @@ namespace UI_DSM.Client.Services.ReviewService
             {
                 throw new HttpRequestException(response.ReasonPhrase);
             }
-            var content = await response.Content.ReadAsStringAsync();
             return this.jsonService.Deserialize<Dictionary<Guid, ComputedProjectProperties>>(await response.Content.ReadAsStreamAsync());
         }
     }

--- a/UI_DSM/UI_DSM.Client/ViewModels/Components/NormalUser/ProjectReview/IProjectReviewViewModel.cs
+++ b/UI_DSM/UI_DSM.Client/ViewModels/Components/NormalUser/ProjectReview/IProjectReviewViewModel.cs
@@ -14,6 +14,7 @@
 namespace UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview
 {
     using Microsoft.AspNetCore.Components;
+    using UI_DSM.Shared.DTO.Common;
     using UI_DSM.Shared.Models;
 
     /// <summary>
@@ -25,6 +26,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview
         ///     The <see cref="Project" />
         /// </summary>
         Project Project { get; set; }
+
+        /// <summary>
+        ///     A collection of comments and tasks <see cref="Review" /> for the user
+        /// </summary>
+        Dictionary<Guid, ComputedProjectProperties> CommentsAndTasks { get; set; }
 
 
         /// <summary>

--- a/UI_DSM/UI_DSM.Client/ViewModels/Components/NormalUser/ProjectReview/ProjectReviewViewModel.cs
+++ b/UI_DSM/UI_DSM.Client/ViewModels/Components/NormalUser/ProjectReview/ProjectReviewViewModel.cs
@@ -17,6 +17,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview
     using ReactiveUI;
 
     using UI_DSM.Client.Components.NormalUser.ProjectReview;
+    using UI_DSM.Shared.DTO.Common;
     using UI_DSM.Shared.Models;
 
     /// <summary>
@@ -37,6 +38,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview
             get => this.project;
             set => this.RaiseAndSetIfChanged(ref this.project, value);
         }
+
+        /// <summary>
+        ///     A collection of comments and tasks <see cref="Review" /> for the user
+        /// </summary>
+        public Dictionary<Guid, ComputedProjectProperties> CommentsAndTasks { get; set; } = new();
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ProjectReviewViewModel" /> class.

--- a/UI_DSM/UI_DSM.Client/ViewModels/Pages/IIndexViewModel.cs
+++ b/UI_DSM/UI_DSM.Client/ViewModels/Pages/IIndexViewModel.cs
@@ -17,8 +17,9 @@ namespace UI_DSM.Client.ViewModels.Pages
     
     using Microsoft.AspNetCore.Components;
     using Microsoft.AspNetCore.Components.Authorization;
-
+  
     using UI_DSM.Shared.Models;
+    using UI_DSM.Shared.DTO.Common;
 
     /// <summary>
     ///     Interface definition for <see cref="IndexViewModel" />
@@ -41,6 +42,11 @@ namespace UI_DSM.Client.ViewModels.Pages
         ///     A collection of available <see cref="Project" /> for the user
         /// </summary>
         SourceList<Project> AvailableProject { get; }
+
+        /// <summary>
+        ///     A collection of comments and tasks <see cref="Project" /> for the user
+        /// </summary>
+        public Dictionary<Guid, ComputedProjectProperties> CommentsAndTasks { get; set; }
 
         /// <summary>
         ///     Navigate to the page dedicated to the given <see cref="Project" />

--- a/UI_DSM/UI_DSM.Client/ViewModels/Pages/IndexViewModel.cs
+++ b/UI_DSM/UI_DSM.Client/ViewModels/Pages/IndexViewModel.cs
@@ -20,6 +20,7 @@ namespace UI_DSM.Client.ViewModels.Pages
     
     using UI_DSM.Client.Pages;
     using UI_DSM.Client.Services.Administration.ProjectService;
+    using UI_DSM.Shared.DTO.Common;
     using UI_DSM.Shared.Models;
 
     /// <summary>
@@ -63,6 +64,11 @@ namespace UI_DSM.Client.ViewModels.Pages
         public SourceList<Project> AvailableProject { get; } = new();
 
         /// <summary>
+        ///     A collection of comments and tasks <see cref="Project" /> for the user
+        /// </summary>
+        public Dictionary<Guid, ComputedProjectProperties> CommentsAndTasks { get; set; } = new();
+
+        /// <summary>
         ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()
@@ -86,9 +92,11 @@ namespace UI_DSM.Client.ViewModels.Pages
         public async Task PopulateAvailableProjects(AuthenticationState state)
         {
             this.AvailableProject.Clear();
+            
             if (state.User.Identity is { IsAuthenticated: true })
             {
-                this.AvailableProject.AddRange(await this.projectService.GetUserParticipation());
+                this.CommentsAndTasks = await this.projectService.GetOpenTasksAndComments();
+                this.AvailableProject.AddRange(await this.projectService.GetUserParticipation());             
             }
         }
         

--- a/UI_DSM/UI_DSM.Client/ViewModels/Pages/NormalUser/ProjectPage/NormalProjectPageViewModel.cs
+++ b/UI_DSM/UI_DSM.Client/ViewModels/Pages/NormalUser/ProjectPage/NormalProjectPageViewModel.cs
@@ -17,6 +17,7 @@ namespace UI_DSM.Client.ViewModels.Pages.NormalUser.ProjectPage
 
     using UI_DSM.Client.Components.NormalUser.ProjectReview;
     using UI_DSM.Client.Services.Administration.ProjectService;
+    using UI_DSM.Client.Services.ReviewService;
     using UI_DSM.Client.ViewModels.Components;
     using UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview;
     using UI_DSM.Shared.Models;
@@ -32,14 +33,20 @@ namespace UI_DSM.Client.ViewModels.Pages.NormalUser.ProjectPage
         /// </summary>
         private readonly IProjectService projectService;
 
+        /// <summary>
+        ///     The <see cref="IReviewService" />
+        /// </summary>
+        private readonly IReviewService reviewService;
+
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="ProjectPageViewModel" /> class.
         /// </summary>
         /// <param name="projectService">The <see cref="IProjectService" /></param>
-        public NormalProjectPageViewModel(IProjectService projectService, IProjectReviewViewModel projectReviewViewModal)
+        public NormalProjectPageViewModel(IProjectService projectService, IReviewService reviewService, IProjectReviewViewModel projectReviewViewModal)
         {
             this.projectService = projectService;
+            this.reviewService = reviewService;
             this.ProjectReviewViewModel = projectReviewViewModal;
         }
 
@@ -67,6 +74,7 @@ namespace UI_DSM.Client.ViewModels.Pages.NormalUser.ProjectPage
         {
             var projectResponse = await this.projectService.GetProject(projectGuid, 1);
             this.ProjectReviewViewModel.Project = projectResponse;
+            ProjectReviewViewModel.CommentsAndTasks = await this.reviewService.GetOpenTasksAndComments(projectGuid);
         }
     }
 }

--- a/UI_DSM/UI_DSM.Server.Tests/Modules/ProjectModuleTestFixture.cs
+++ b/UI_DSM/UI_DSM.Server.Tests/Modules/ProjectModuleTestFixture.cs
@@ -186,28 +186,25 @@ namespace UI_DSM.Server.Tests.Modules
         [Test]
         public async Task VerifyGetOpenTasksAndComments()
         {
-            await this.module.GetOpenTasksAndComments(this.projectManager.As<IProjectManager>().Object, null, this.httpContext.Object);
-            this.httpResponse.VerifySet(x => x.StatusCode = 400, Times.Once);
-
-            var guids = new List<Guid>
+            var projects = new List<Project>
             {
-                Guid.NewGuid()
+                new(Guid.NewGuid())
             };
-
+            this.projectManager.As<IProjectManager>().Setup(x => x.GetAvailableProjectsForUser(It.IsAny<string>()))
+                .ReturnsAsync(this.projects);
+            var guids = projects.Select(x => x.Id).ToList();
             var result = new Dictionary<Guid, ComputedProjectProperties>
             {
-                [guids[0]] = new ()
+                [guids[0]] = new()
                 {
                     CommentCount = 15,
                     TaskCount = 12
                 }
             };
-
-            this.projectManager.As<IProjectManager>().Setup(x => x.GetOpenTasksAndComments(guids, "user"))
+            this.projectManager.As<IProjectManager>().Setup(x => x.GetOpenTasksAndComments(It.IsAny<IEnumerable<Guid>>(), "user"))
                 .ReturnsAsync(result);
-
-            await this.module.GetOpenTasksAndComments(this.projectManager.As<IProjectManager>().Object, guids, this.httpContext.Object);
-            this.projectManager.As<IProjectManager>().Verify(x => x.GetOpenTasksAndComments(guids, "user"), Times.Once);
+            await this.module.GetOpenTasksAndComments(this.projectManager.As<IProjectManager>().Object, this.httpContext.Object);
+            this.projectManager.As<IProjectManager>().Verify(x => x.GetOpenTasksAndComments(It.IsAny<IEnumerable<Guid>>(), "user"), Times.Once);
         }
     }
 }

--- a/UI_DSM/UI_DSM.Server.Tests/Modules/ReviewModuleTestFixture.cs
+++ b/UI_DSM/UI_DSM.Server.Tests/Modules/ReviewModuleTestFixture.cs
@@ -30,6 +30,7 @@ namespace UI_DSM.Server.Tests.Modules
     using UI_DSM.Server.Types;
     using UI_DSM.Server.Validator;
     using UI_DSM.Shared.DTO.Models;
+    using UI_DSM.Shared.DTO.Common;
     using UI_DSM.Shared.Enumerator;
     using UI_DSM.Shared.Models;
 
@@ -274,6 +275,32 @@ namespace UI_DSM.Server.Tests.Modules
             this.reviewManager.Setup(x => x.UpdateEntity(It.IsAny<Review>())).ReturnsAsync(EntityOperationResult<Review>.Success(review));
             await this.module.UpdateEntity(this.reviewManager.Object, review.Id, reviewDto, this.context.Object);
             this.response.VerifySet(x => x.StatusCode = 200, Times.Once);
+        }
+
+         [Test]
+        public async Task VerifyGetOpenTasksAndComments()
+        {
+            var reviews = new List<Review>
+            {
+                new(Guid.NewGuid())
+            };
+
+            Project project = new(Guid.NewGuid());
+            project.Reviews.AddRange(reviews);
+
+
+            var guids = reviews.Select(x => x.Id).ToList();
+            var result = new Dictionary<Guid, ComputedProjectProperties>
+            {
+                [guids[0]] = new()
+                {
+                    CommentCount = 15,
+                    TaskCount = 12
+                }
+            };
+            this.reviewManager.As<IReviewManager>().Setup(x => x.GetOpenTasksAndComments(It.IsAny<IEnumerable<Guid>>())).Returns(result);
+            await this.module.GetOpenTasksAndComments(this.reviewManager.As<IReviewManager>().Object,project.Id, this.context.Object);
+            this.reviewManager.As<IReviewManager>().Verify(x => x.GetOpenTasksAndComments(It.IsAny<IEnumerable<Guid>>()), Times.Once);
         }
     }
 }

--- a/UI_DSM/UI_DSM.Server/Managers/ReviewManager/IReviewManager.cs
+++ b/UI_DSM/UI_DSM.Server/Managers/ReviewManager/IReviewManager.cs
@@ -27,7 +27,7 @@ namespace UI_DSM.Server.Managers.ReviewManager
         ///     and <see cref="Comment" /> for each <see cref="Review" />
         /// </summary>
         /// <param name="reviewsId">A collection of <see cref="Guid" /> for <see cref="Review" />s</param>
-        /// <returns>A <see cref="Task" /> with the <see cref="Dictionary{Guid,ComputedProjectProperties}" /></returns>
-        Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments(IEnumerable<Guid> reviewsId);
+        /// <returns> A <see cref="Dictionary{Guid,ComputedProjectProperties}" /></returns>
+        Dictionary<Guid, ComputedProjectProperties> GetOpenTasksAndComments(IEnumerable<Guid> reviewsId);
     }
 }

--- a/UI_DSM/UI_DSM.Server/Managers/ReviewManager/IReviewManager.cs
+++ b/UI_DSM/UI_DSM.Server/Managers/ReviewManager/IReviewManager.cs
@@ -13,6 +13,7 @@
 
 namespace UI_DSM.Server.Managers.ReviewManager
 {
+    using UI_DSM.Shared.DTO.Common;
     using UI_DSM.Shared.Models;
 
     /// <summary>
@@ -20,5 +21,13 @@ namespace UI_DSM.Server.Managers.ReviewManager
     /// </summary>
     public interface IReviewManager : IContainedEntityManager<Review>
     {
+
+        /// <summary>
+        ///     Gets the number of open <see cref="ReviewTask" /> where the logged user is assigned to
+        ///     and <see cref="Comment" /> for each <see cref="Review" />
+        /// </summary>
+        /// <param name="reviewsId">A collection of <see cref="Guid" /> for <see cref="Review" />s</param>
+        /// <returns>A <see cref="Task" /> with the <see cref="Dictionary{Guid,ComputedProjectProperties}" /></returns>
+        Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments(IEnumerable<Guid> reviewsId);
     }
 }

--- a/UI_DSM/UI_DSM.Server/Managers/ReviewManager/ReviewManager.cs
+++ b/UI_DSM/UI_DSM.Server/Managers/ReviewManager/ReviewManager.cs
@@ -95,9 +95,9 @@ namespace UI_DSM.Server.Managers.ReviewManager
         ///     Gets the number of open <see cref="ReviewTask" /> where the logged user is assigned to
         ///     and <see cref="Comment" /> for each <see cref="Project" />
         /// </summary>
-        /// <param name="projectsId">A collection of <see cref="Guid" /> for <see cref="Project" />s</param>
-        /// <returns>A <see cref="Task" /> with the <see cref="Dictionary{Guid,ComputedProjectProperties}" /></returns>
-        public async Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments(IEnumerable<Guid> reviewsId)
+        /// <param name="reviewsId">A collection of <see cref="Guid" /> for <see cref="Review" />s</param>
+        /// <returns> A <see cref="Dictionary{Guid,ComputedProjectProperties}" /></returns>
+        public Dictionary<Guid, ComputedProjectProperties> GetOpenTasksAndComments(IEnumerable<Guid> reviewsId)
         {
             var dictionary = new Dictionary<Guid, ComputedProjectProperties>();
 
@@ -119,8 +119,8 @@ namespace UI_DSM.Server.Managers.ReviewManager
         ///     and <see cref="Comment" /> for a <see cref="Review" />
         /// </summary>
         /// <param name="reviewId">A <see cref="Guid" /> for <see cref="Review" /></param>
-        /// <returns>A <see cref="Task" />with the <see cref="ComputedProjectProperties" /></returns>
-        private  ComputedProjectProperties GetOpenTasksAndComments(Guid reviewId)
+        /// <returns> A <see cref="ComputedProjectProperties" /></returns>
+        private ComputedProjectProperties GetOpenTasksAndComments(Guid reviewId)
         {
             if (this.EntityDbSet.All(x => x.Id != reviewId))
             {

--- a/UI_DSM/UI_DSM.Server/Managers/ReviewManager/ReviewManager.cs
+++ b/UI_DSM/UI_DSM.Server/Managers/ReviewManager/ReviewManager.cs
@@ -18,6 +18,7 @@ namespace UI_DSM.Server.Managers.ReviewManager
     using UI_DSM.Server.Managers.ArtifactManager;
     using UI_DSM.Server.Managers.ParticipantManager;
     using UI_DSM.Server.Managers.ReviewObjectiveManager;
+    using UI_DSM.Shared.DTO.Common;
     using UI_DSM.Shared.DTO.Models;
     using UI_DSM.Shared.Enumerator;
     using UI_DSM.Shared.Models;
@@ -88,6 +89,62 @@ namespace UI_DSM.Server.Managers.ReviewManager
             entity.ReviewNumber = project!.Reviews.Max(x => x.ReviewNumber) + 1;
             entity.CreatedOn = DateTime.UtcNow;
             entity.Status = StatusKind.Open;
+        }
+
+        /// <summary>
+        ///     Gets the number of open <see cref="ReviewTask" /> where the logged user is assigned to
+        ///     and <see cref="Comment" /> for each <see cref="Project" />
+        /// </summary>
+        /// <param name="projectsId">A collection of <see cref="Guid" /> for <see cref="Project" />s</param>
+        /// <returns>A <see cref="Task" /> with the <see cref="Dictionary{Guid,ComputedProjectProperties}" /></returns>
+        public async Task<Dictionary<Guid, ComputedProjectProperties>> GetOpenTasksAndComments(IEnumerable<Guid> reviewsId)
+        {
+            var dictionary = new Dictionary<Guid, ComputedProjectProperties>();
+
+            foreach (var reviewId in reviewsId)
+            {
+                var computedProperties = this.GetOpenTasksAndComments(reviewId);
+
+                if (computedProperties != null)
+                {
+                    dictionary[reviewId] = computedProperties;
+                }
+            }
+
+            return dictionary;
+        }
+
+        /// <summary>
+        ///     Gets the number of open <see cref="ReviewTask" /> where the logged user is assigned to
+        ///     and <see cref="Comment" /> for a <see cref="Review" />
+        /// </summary>
+        /// <param name="reviewId">A <see cref="Guid" /> for <see cref="Review" /></param>
+        /// <returns>A <see cref="Task" />with the <see cref="ComputedProjectProperties" /></returns>
+        private  ComputedProjectProperties GetOpenTasksAndComments(Guid reviewId)
+        {
+            if (this.EntityDbSet.All(x => x.Id != reviewId))
+            {
+                return null;
+            }
+
+            var tasks = this.EntityDbSet
+                .Where(x => x.Id == reviewId)
+                .SelectMany(x => x.ReviewObjectives)
+                .SelectMany(x => x.ReviewTasks)
+                .Count(x => x.Status == StatusKind.Open);
+
+            var comments = this.EntityDbSet
+                .Where(x => x.Id == reviewId)
+                .SelectMany(x => x.ReviewObjectives)
+                .SelectMany(x => x.Annotations)
+                .OfType<Comment>()
+                .Count();
+
+            return new ComputedProjectProperties
+            {
+                TaskCount = tasks,
+                CommentCount = comments
+            };
         }
     }
 }

--- a/UI_DSM/UI_DSM.Server/Modules/ContainedEntityModule.cs
+++ b/UI_DSM/UI_DSM.Server/Modules/ContainedEntityModule.cs
@@ -101,7 +101,7 @@ namespace UI_DSM.Server.Modules
                 return;
             }
 
-            await context.Response.Negotiate(entity.GetAssociatedEntities(deepLevel).ToDtos());
+            await context.Response.Negotiate((await manager.GetEntity(entityId, deepLevel)).ToDtos());
         }
 
         /// <summary>

--- a/UI_DSM/UI_DSM.Server/Modules/ProjectModule.cs
+++ b/UI_DSM/UI_DSM.Server/Modules/ProjectModule.cs
@@ -46,7 +46,6 @@ namespace UI_DSM.Server.Modules
                 .WithName($"{this.EntityName}/GetProjectsForUser");
 
             app.MapGet($"{this.MainRoute}/OpenTasksAndComments", this.GetOpenTasksAndComments)
-                .Accepts<IEnumerable<Guid>>("application/json")
                 .Produces<Dictionary<Guid, ComputedProjectProperties>>()
                 .WithTags(this.EntityName)
                 .WithName($"{this.EntityName}/GetOpenTasksAndComments");
@@ -140,17 +139,12 @@ namespace UI_DSM.Server.Modules
         ///     related to the <see cref="Project" />
         /// </summary>
         /// <param name="projectManager">The <see cref="IProjectManager"/></param>
-        /// <param name="projectsId">A collection of <see cref="Guid"/></param>
         /// <param name="context">The <see cref="HttpContext"/></param>
         /// <returns>A <see cref="Task"/></returns>
         [Authorize]
-        public async Task GetOpenTasksAndComments(IProjectManager projectManager, IEnumerable<Guid> projectsId, HttpContext context)
+        public async Task GetOpenTasksAndComments(IProjectManager projectManager, HttpContext context)
         {
-            if(projectsId == null)
-            {
-                context.Response.StatusCode = 400;
-                return;
-            }
+            var projectsId = (await projectManager.GetAvailableProjectsForUser(context.User.Identity?.Name)).Select(x => x.Id) ;
 
             var computedProperties = await projectManager.GetOpenTasksAndComments(projectsId, context.User.Identity?.Name);
             await context.Response.Negotiate(computedProperties);

--- a/UI_DSM/UI_DSM.Server/Modules/ReviewModule.cs
+++ b/UI_DSM/UI_DSM.Server/Modules/ReviewModule.cs
@@ -175,13 +175,14 @@ namespace UI_DSM.Server.Modules
         ///     related to the <see cref="Review" />
         /// </summary>
         /// <param name="reviewManager">The <see cref="IReviewManager"/></param>
+        /// <param name="projectId"> The <see cref="Guid"/> of the <see cref="Project" /></param>
         /// <param name="context">The <see cref="HttpContext"/></param>
         /// <returns>A <see cref="Task"/></returns>
         [Authorize]
         public async Task GetOpenTasksAndComments(IReviewManager reviewManager,Guid projectId, HttpContext context)
         {
             var reviewsId = (await reviewManager.GetContainedEntities(projectId)).Select(x => x.Id);
-            var computedProperties = await reviewManager.GetOpenTasksAndComments(reviewsId);
+            var computedProperties =  reviewManager.GetOpenTasksAndComments(reviewsId);
             await context.Response.Negotiate(computedProperties);
         }
     }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/UI-DSM/pulls) open
- [x] I have verified that I am following the UI-DSM [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/UI-DSM/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #78 #73 
In this commit i have added a new route to fetch review's comments and tasks and link the data to review card. I have also linked the real data to project card (creation date, comments and tasks)
I have added coverage for testing all the services, modules and managers.

<!-- Thanks for contributing to UI-DSM! -->