### PR TITLE
More content inside context panel : Fix #160

### DIFF
--- a/UI_DSM.Client.Tests/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizerTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizerTestFixture.cs
@@ -1,0 +1,222 @@
+﻿// --------------------------------------------------------------------------------------------------------
+// <copyright file="ParameterValuesVisualizerTestFixture.cs" company="RHEA System S.A.">
+//  Copyright (c) 2022 RHEA System S.A.
+// 
+//  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+//  This file is part of UI-DSM.
+//  The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+//  The UI-DSM application is provided to the community under the Apache License 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------
+
+namespace UI_DSM.Client.Tests.Components.App.ParameterValuesVisualizer
+{
+    using Bunit;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+    
+    using NUnit.Framework;
+
+    using UI_DSM.Client.Components.App.ParameterValuesVisualizer;
+    using UI_DSM.Client.Tests.Helpers;
+
+    using TestContext = Bunit.TestContext;
+
+    [TestFixture]
+    public class ParameterValuesVisualizerTestFixture
+    {
+        private TestContext context;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.context = new TestContext();
+            this.context.ConfigureDevExpressBlazor();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.context.CleanContext();
+        }
+
+        [Test]
+        public void VerifyComponentWithScalarParameterType()
+        {
+            var scalar = new BooleanParameterType()
+            {
+                Name = "bool param",
+                ShortName = "bp"
+            };
+
+            var parameter = new Parameter()
+            {
+                ParameterType = scalar
+            };
+            
+            parameter.ValueSet.Add(new ParameterValueSet()
+            {
+                Manual = new ValueArray<string>(new List<string>{"true"}),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            var renderer = this.context.RenderComponent<ParameterValuesVisualizer>(parameters =>
+            {
+                parameters.Add(p => p.Parameter, parameter);
+                parameters.Add(p => p.Option, new Option());
+            });
+
+            Assert.That(renderer.FindAll("button"), Is.Empty);
+
+            parameter.StateDependence = new ActualFiniteStateList()
+            {
+                ActualState =
+                {
+                    new ActualFiniteState(),
+                    new ActualFiniteState()
+                }
+            };
+
+            parameter.ValueSet.Clear();
+
+            parameter.ValueSet.Add(new ParameterValueSet()
+            {
+                Manual = new ValueArray<string>(new List<string> { "true" }),
+                ValueSwitch = ParameterSwitchKind.MANUAL,
+                ActualState = parameter.StateDependence.ActualState.First()
+            });
+
+            parameter.ValueSet.Add(new ParameterValueSet()
+            {
+                Manual = new ValueArray<string>(new List<string> { "false" }),
+                ValueSwitch = ParameterSwitchKind.MANUAL,
+                ActualState = parameter.StateDependence.ActualState.Last()
+            });
+
+            renderer = this.context.RenderComponent<ParameterValuesVisualizer>(parameters =>
+            {
+                parameters.Add(p => p.Parameter, parameter);
+                parameters.Add(p => p.Option, new Option());
+            });
+
+            Assert.That(() => renderer.Find("button"), Throws.Nothing);
+        }
+
+        [Test]
+        public void VerifyComponentWithQuantityKindParameterType()
+        {
+            var scale = new RatioScale()
+            {
+                Name = "kilogram",
+                ShortName = "kg"
+            };
+
+            var scalar = new SimpleQuantityKind()
+            {
+                Name = "bool param",
+                ShortName = "bp",
+                PossibleScale = {scale}
+            };
+
+            var parameter = new Parameter()
+            {
+                ParameterType = scalar,
+                Scale = scale
+            };
+
+            parameter.ValueSet.Add(new ParameterValueSet()
+            {
+                Manual = new ValueArray<string>(new List<string> { "4.5" }),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            var renderer = this.context.RenderComponent<ParameterValuesVisualizer>(parameters =>
+            {
+                parameters.Add(p => p.Parameter, parameter);
+                parameters.Add(p => p.Option, new Option());
+            });
+
+            Assert.That(renderer.FindAll("button"), Is.Empty);
+
+            parameter.StateDependence = new ActualFiniteStateList()
+            {
+                ActualState =
+                {
+                    new ActualFiniteState(),
+                    new ActualFiniteState()
+                }
+            };
+
+            parameter.ValueSet.Clear();
+
+            parameter.ValueSet.Add(new ParameterValueSet()
+            {
+                Manual = new ValueArray<string>(new List<string> { "4.5" }),
+                ValueSwitch = ParameterSwitchKind.MANUAL,
+                ActualState = parameter.StateDependence.ActualState.First()
+            });
+
+            parameter.ValueSet.Add(new ParameterValueSet()
+            {
+                Manual = new ValueArray<string>(new List<string> { "4.8" }),
+                ValueSwitch = ParameterSwitchKind.MANUAL,
+                ActualState = parameter.StateDependence.ActualState.Last()
+            });
+
+            renderer = this.context.RenderComponent<ParameterValuesVisualizer>(parameters =>
+            {
+                parameters.Add(p => p.Parameter, parameter);
+                parameters.Add(p => p.Option, new Option());
+            });
+
+            Assert.That(() => renderer.Find("button"), Throws.Nothing);
+        }
+
+        [Test]
+        public void VerifyComponentWithCompoundParameterType()
+        {
+            var compound = new CompoundParameterType()
+            {
+                Name = "Dimension",
+            };
+
+            compound.Component.Add(new ParameterTypeComponent()
+            {
+                ShortName = "DimX"
+            });
+
+            compound.Component.Add(new ParameterTypeComponent()
+            {
+                ShortName = "DimY"
+            });
+
+            compound.Component.Add(new ParameterTypeComponent()
+            {
+                ShortName = "DimZ"
+            });
+
+            var parameter = new Parameter()
+            {
+                ParameterType = compound
+            };
+
+            parameter.ValueSet.Add(new ParameterValueSet()
+            {
+                Manual = new ValueArray<string>(new List<string> { "4.5", "4.2", "4.3" }),
+                ValueSwitch = ParameterSwitchKind.MANUAL
+            });
+
+            var renderer = this.context.RenderComponent<ParameterValuesVisualizer>(parameters =>
+            {
+                parameters.Add(p => p.Parameter, parameter);
+                parameters.Add(p => p.Option, new Option());
+            });
+
+            Assert.That(() => renderer.Find("button"), Throws.Nothing);
+        }
+    }
+}

--- a/UI_DSM.Client/Components/App/AppKeyValues/AppKeyValues.razor
+++ b/UI_DSM.Client/Components/App/AppKeyValues/AppKeyValues.razor
@@ -12,7 +12,7 @@
 @namespace AppComponents
 
 <div class="app-key-values">
-	<AppAccordion Label="@(this.Key)" Variant="AppAccordion.VariantValue.Tiny">
+	<AppAccordion Label="@(this.Key)" Variant="AppAccordion.VariantValue.Tiny" PanelOpen="false">
 		<ul class="app-key-values__list">
 			@foreach (var item in this.Items)
 			{

--- a/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor
+++ b/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor
@@ -1,0 +1,66 @@
+﻿@using CDP4Common.SiteDirectoryData
+<!--------------------------------------------------------------------------------------------------------
+// ParameterValuesVisualizer.razor
+// Copyright (c) 2022 RHEA System S.A.
+// 
+// Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+// This file is part of UI-DSM. 
+// The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+// The UI-DSM application is provided to the community under the Apache License 2.0.
+-------------------------------------------------------------------------------------------------------->
+@if (this.hasMultipleValues)
+{
+	<DxPopup @ref=@this.Popup HeaderText="Values Visualizer" ShowFooter="false">
+		<Content>
+			@this.Parameter.ParameterType.Name
+			@if (this.Parameter.StateDependence == null)
+			{
+				if (this.Parameter.ParameterType is ScalarParameterType)
+				{
+					if (this.Parameter.Scale != null)
+					{
+						<span> (@this.Parameter.Scale.ShortName) </span>
+					}
+					<ScalarValuesVisualizer Parameter="@this.Parameter" Option="@this.Option" State="null"/>
+				}
+				else
+				{
+					<CompoundValuesVisualizer Parameter="@this.Parameter" Option="@this.Option" State="null"/>
+				}
+			}
+			else
+			{
+				if (this.Parameter.ParameterType is ScalarParameterType && this.Parameter.Scale != null)
+				{
+					<span> (@this.Parameter.Scale.ShortName) </span>
+				}
+				foreach (var actualFiniteState in this.Parameter.StateDependence.ActualState)
+				{
+					if (this.Parameter.ParameterType is ScalarParameterType)
+					{
+						<ScalarValuesVisualizer Parameter="@this.Parameter" Option="@this.Option" State="actualFiniteState"/>
+					}
+					else
+					{
+						<CompoundValuesVisualizer Parameter="@this.Parameter" Option="@this.Option" State="actualFiniteState"/>
+					}
+				}
+			}
+		</Content>
+	</DxPopup>
+}
+
+<div class="app-key-value">
+	<span class="app-key-value__key">@(this.Parameter.ParameterType.Name)</span>
+	<span class="app-key-value__value">
+		@{
+			@this.displayValue
+			if (this.hasMultipleValues)
+			{
+				<button @onclick="@this.OpenPopup" class="more">more</button>
+			}
+		}
+	</span>
+</div>

--- a/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor
+++ b/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor
@@ -1,5 +1,4 @@
-﻿@using CDP4Common.SiteDirectoryData
-<!--------------------------------------------------------------------------------------------------------
+﻿<!--------------------------------------------------------------------------------------------------------
 // ParameterValuesVisualizer.razor
 // Copyright (c) 2022 RHEA System S.A.
 // 
@@ -10,6 +9,8 @@
 // 
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
+@using CDP4Common.SiteDirectoryData
+
 @if (this.hasMultipleValues)
 {
 	<DxPopup @ref=@this.Popup HeaderText="Values Visualizer" ShowFooter="false">

--- a/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor.cs
+++ b/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor.cs
@@ -61,12 +61,8 @@ namespace UI_DSM.Client.Components.App.ParameterValuesVisualizer
         protected override void OnParametersSet()
         {
             base.OnParametersSet();
-
-            if (this.Parameter != null)
-            {
-                this.displayValue = this.ComputeDisplayValue();
-                this.hasMultipleValues = this.ComputeHasMultipleValues();
-            }
+            this.displayValue = this.ComputeDisplayValue();
+            this.hasMultipleValues = this.ComputeHasMultipleValues();
         }
 
         /// <summary>

--- a/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor.cs
+++ b/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor.cs
@@ -1,0 +1,130 @@
+﻿// --------------------------------------------------------------------------------------------------------
+// <copyright file="ParameterValuesVisualizer.razor.cs" company="RHEA System S.A.">
+//  Copyright (c) 2022 RHEA System S.A.
+// 
+//  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+//  This file is part of UI-DSM.
+//  The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+//  The UI-DSM application is provided to the community under the Apache License 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------
+
+namespace UI_DSM.Client.Components.App.ParameterValuesVisualizer
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using DevExpress.Blazor;
+
+    using Microsoft.AspNetCore.Components;
+
+    using UI_DSM.Client.Extensions;
+
+    /// <summary>
+    ///     Component that enables to see all values of a <see cref="ParameterOrOverrideBase" />
+    /// </summary>
+    public partial class ParameterValuesVisualizer
+    {
+        /// <summary>
+        ///     The value to display
+        /// </summary>
+        private string displayValue;
+
+        /// <summary>
+        ///     Value asserting that the <see cref="Parameter" /> has more than one value
+        /// </summary>
+        private bool hasMultipleValues;
+
+        /// <summary>
+        ///     The <see cref="ParameterOrOverrideBase" />
+        /// </summary>
+        [Parameter]
+        public ParameterOrOverrideBase Parameter { get; set; }
+
+        /// <summary>
+        ///     The <see cref="Option" />
+        /// </summary>
+        [Parameter]
+        public Option Option { get; set; }
+
+        /// <summary>
+        ///     Reference to the <see cref="DxPopup" />
+        /// </summary>
+        public DxPopup Popup { get; set; }
+
+        /// <summary>
+        ///     Method invoked when the component has received parameters from its parent in
+        ///     the render tree, and the incoming values have been assigned to properties.
+        /// </summary>
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+
+            if (this.Parameter != null)
+            {
+                this.displayValue = this.ComputeDisplayValue();
+                this.hasMultipleValues = this.ComputeHasMultipleValues();
+            }
+        }
+
+        /// <summary>
+        ///     Verifies that the current <see cref="Parameter" /> has more than one value
+        /// </summary>
+        /// <returns>True if the <see cref="Parameter" /> has multiple values</returns>
+        private bool ComputeHasMultipleValues()
+        {
+            if (this.Parameter.StateDependence != null)
+            {
+                return true;
+            }
+
+            return this.Parameter.ParameterType switch
+            {
+                CompoundParameterType => true,
+                _ => false
+            };
+        }
+
+        /// <summary>
+        ///     Computes the value to display
+        /// </summary>
+        /// <returns>The value</returns>
+        private string ComputeDisplayValue()
+        {
+            var actualFiniteState = this.Parameter.StateDependence?.ActualState[0];
+
+            return this.Parameter.ParameterType switch
+            {
+                CompoundParameterType compoundParameterType => GetCompoundParameterTypeHeader(compoundParameterType),
+                QuantityKind => actualFiniteState != null
+                    ? $"{actualFiniteState.Name} : {this.Parameter.GetParameterValue(this.Option, actualFiniteState)} ({this.Parameter.Scale.ShortName})"
+                    : $"{this.Parameter.GetParameterValue(this.Option, null)} ({this.Parameter.Scale.ShortName})",
+                ScalarParameterType => actualFiniteState != null
+                    ? $"{actualFiniteState.Name} : {this.Parameter.GetParameterValue(this.Option, actualFiniteState)}"
+                    : $"{this.Parameter.GetParameterValue(this.Option, null)}",
+                _ => "-"
+            };
+        }
+
+        /// <summary>
+        ///     Gets the header of a <see cref="CompoundParameterType" />
+        /// </summary>
+        /// <param name="compoundParameterType">The <see cref="CompoundParameterType" /></param>
+        /// <returns>The header</returns>
+        private static string GetCompoundParameterTypeHeader(CompoundParameterType compoundParameterType)
+        {
+            return $"[{string.Join(", ", compoundParameterType.Component.Select(x => x.ShortName))}]";
+        }
+
+        /// <summary>
+        ///     Opens the <see cref="DxPopup" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        private Task OpenPopup()
+        {
+            return this.Popup.ShowAsync();
+        }
+    }
+}

--- a/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor.css
+++ b/UI_DSM.Client/Components/App/ParameterValuesVisualizer/ParameterValuesVisualizer.razor.css
@@ -1,0 +1,30 @@
+﻿.app-key-value {
+    padding: var(--spacing-2) var(--spacing-4);
+    border-bottom: 1px solid var(--colors-gray-50);
+    font-size: var(--text-sm);
+    gap: var(--spacing-2);
+    line-height: 130%;
+}
+
+.app-key-value--horizontal {
+    display: flex;
+    justify-content: space-between;
+}
+
+.app-key-value--vertical {
+    display: grid;
+}
+
+.app-key-value__key {
+    color: var(--colors-gray-500);
+}
+
+.app-key-value__value {
+    color: var(--colors-gray-700);
+    font-weight: 500;
+}
+
+.more {
+    color: var(--colors-primary-500);
+    text-decoration: underline;
+}

--- a/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor
+++ b/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor
@@ -1,5 +1,5 @@
 ﻿<!--------------------------------------------------------------------------------------------------------
-// PortSelectedItem.razor
+// ParametersComponent.razor
 // Copyright (c) 2022 RHEA System S.A.
 // 
 // Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
@@ -9,8 +9,13 @@
 // 
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
-@inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.PortRowViewModel>
-<AppKeyValue Key="Name" Value="@(this.RowViewModel.Id)" />
-<AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)" />
-<AppKeyValue Key="Product Container" Value="@(this.RowViewModel.Container)" />
-<AppKeyValue Key="Interface End" Value="@(this.RowViewModel.InterfaceEnd)" />
+<div class="app-key-values">
+	<AppAccordion Label="Parameters" Variant="AppAccordion.VariantValue.Tiny" PanelOpen="false">
+		<ul class="app-key-values__list">
+			@foreach (var item in this.Parameters)
+			{
+				<li><ParameterValuesVisualizer Parameter="item" Option="this.CurrentOption"/></li>
+			}
+		</ul>
+	</AppAccordion>
+</div>

--- a/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor.cs
+++ b/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor.cs
@@ -1,0 +1,37 @@
+﻿// --------------------------------------------------------------------------------------------------------
+// <copyright file="ParametersComponent.cs" company="RHEA System S.A.">
+//  Copyright (c) 2022 RHEA System S.A.
+// 
+//  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+//  This file is part of UI-DSM.
+//  The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+//  The UI-DSM application is provided to the community under the Apache License 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------
+
+namespace UI_DSM.Client.Components.App.ParametersComponent
+{
+    using CDP4Common.EngineeringModelData;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    ///     Component that display all <see cref="ParameterOrOverrideBase" /> contained into an <see cref="ElementBase" />
+    /// </summary>
+    public partial class ParametersComponent
+    {
+        /// <summary>
+        ///     The collection of <see cref="ParameterOrOverrideBase" />
+        /// </summary>
+        [Parameter]
+        public List<ParameterOrOverrideBase> Parameters { get; set; }
+
+        /// <summary>
+        ///     The current <see cref="Option" />
+        /// </summary>
+        [Parameter]
+        public Option CurrentOption { get; set; }
+    }
+}

--- a/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor.css
+++ b/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor.css
@@ -1,0 +1,4 @@
+﻿.app-key-values__list {
+    list-style: none;
+    padding: 0;
+}

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/ElementBaseSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/ElementBaseSelectedItem.razor
@@ -10,7 +10,8 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 @inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.ElementBaseRowViewModel>
-<AppKeyValue Key="Name" Value="@(this.RowViewModel.Name)" />
-<AppKeyValue Key="ShortName" Value="@(this.RowViewModel.ShortName)" />
-<AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)" />
-<AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)" />
+<AppKeyValue Key="Name" Value="@(this.RowViewModel.Name)"/>
+<AppKeyValue Key="ShortName" Value="@(this.RowViewModel.ShortName)"/>
+<AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)"/>
+<AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)"/>
+<ParametersComponent Parameters="@(this.RowViewModel.Parameters)" CurrentOption="@(this.RowViewModel.CurrentOption)"/>

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/FunctionSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/FunctionSelectedItem.razor
@@ -14,3 +14,6 @@
 <AppKeyValue Key="ShortName" Value="@(this.RowViewModel.ShortName)" />
 <AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)" />
 <AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)" />
+<ParametersComponent Parameters="@(this.RowViewModel.Parameters)" CurrentOption="@(this.RowViewModel.CurrentOption)"/>
+<AppKeyValues Key="Implemented by product(s)" Items="@(this.RowViewModel.ProductsImplement)" />
+<AppKeyValues Key="Satisfies requirement(s)" Items="@(this.RowViewModel.SatisfiedRequirements)" />

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/InterfaceSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/InterfaceSelectedItem.razor
@@ -9,11 +9,16 @@
 // 
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
-@inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.InterfaceRowViewModel>
-<AppKeyValue Key="Name" Value="@(this.RowViewModel.Id)" />
-<AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)" />
-<AppKeyValue Key="Nature" Value="@(this.RowViewModel.Nature)" />
-<AppKeyValue Key="Source" Value="@(this.RowViewModel.SourceEnd)" />
-<AppKeyValue Key="Target" Value="@(this.RowViewModel.TargetEnd)" />
-<AppKeyValue Key="Source Owner" Value="@(this.RowViewModel.SourceOwner)" />
-<AppKeyValue Key="Target Owner" Value="@(this.RowViewModel.TargetOwner)" />
+@using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
+@inherits RelationshipSelectedItem
+
+@{
+	if (this.RowViewModel is InterfaceRowViewModel interfaceRow)
+	{
+		<AppKeyValue Key="Name" Value="@(this.RowViewModel.Id)" />
+		<AppKeyValue Key="Owner" Value="@(interfaceRow.Owner)" />
+		<AppKeyValue Key="Nature" Value="@(interfaceRow.Nature)" />
+	}
+
+	base.BuildRenderTree(__builder);
+}

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/ProductSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/ProductSelectedItem.razor
@@ -14,3 +14,6 @@
 <AppKeyValue Key="ShortName" Value="@(this.RowViewModel.ShortName)"/>
 <AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)"/>
 <AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)" />
+<ParametersComponent Parameters="@(this.RowViewModel.Parameters)" CurrentOption="@(this.RowViewModel.CurrentOption)" />
+<AppKeyValues Key="Implement function(s)" Items="@(this.RowViewModel.ImplementedFunctions)" />
+<AppKeyValues Key="Satisfies requirement(s)" Items="@(this.RowViewModel.SatisfiedRequirements)" />

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RelationshipSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RelationshipSelectedItem.razor
@@ -10,7 +10,9 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 @inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.RelationshipRowViewModel>
-<AppKeyValue Key="Source" Value="@(this.RowViewModel.SourceName)" />
-<AppKeyValue Key="Source Owner" Value="@(this.RowViewModel.SourceOwner)" />
-<AppKeyValue Key="Target" Value="@(this.RowViewModel.TargetName)" />
-<AppKeyValue Key="Target Owner" Value="@(this.RowViewModel.TargetOwner)" />
+<AppAccordion Label="Source Element" Variant="AppAccordion.VariantValue.Small">
+	<DynamicComponent Type="@this.sourceCorrespondance.Item1" Parameters="this.sourceParameters"/>
+</AppAccordion>
+<AppAccordion Label="Target Element" Variant="AppAccordion.VariantValue.Small">
+	<DynamicComponent Type="@this.targetCorrespondance.Item1" Parameters="this.targetParameters"/>
+</AppAccordion>

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RelationshipSelectedItem.razor.cs
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RelationshipSelectedItem.razor.cs
@@ -1,0 +1,60 @@
+﻿// --------------------------------------------------------------------------------------------------------
+// <copyright file="RelationshipSelectedItem.razor.cs" company="RHEA System S.A.">
+//  Copyright (c) 2022 RHEA System S.A.
+// 
+//  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+//  This file is part of UI-DSM.
+//  The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+//  The UI-DSM application is provided to the community under the Apache License 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------
+
+namespace UI_DSM.Client.Components.App.SelectedItemCard.SelectedItemCardContent
+{
+    using Microsoft.AspNetCore.Components;
+
+    using UI_DSM.Client.ViewModels.App.SelectedItemCard;
+    using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel;
+
+    /// <summary>
+    ///     Component to visualize information related when a <see cref="RelationshipRowViewModel" /> is selected
+    /// </summary>
+    public partial class RelationshipSelectedItem
+    {
+        /// <summary>
+        ///     A <see cref="Dictionary{TKey,TValue}" /> for the <see cref="DynamicComponent.Parameters" /> for source
+        /// </summary>
+        private readonly Dictionary<string, object> sourceParameters = new();
+
+        /// <summary>
+        ///     A <see cref="Dictionary{TKey,TValue}" /> for the <see cref="DynamicComponent.Parameters" /> for target
+        /// </summary>
+        private readonly Dictionary<string, object> targetParameters = new();
+
+        /// <summary>
+        ///     The correspondance for the source component
+        /// </summary>
+        private Tuple<Type, string> sourceCorrespondance;
+
+        /// <summary>
+        ///     The correspondance for the target component
+        /// </summary>
+        private Tuple<Type, string> targetCorrespondance;
+
+        /// <summary>
+        ///     Method invoked when the component has received parameters from its parent in
+        ///     the render tree, and the incoming values have been assigned to properties.
+        /// </summary>
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+
+            this.sourceParameters[nameof(this.SelectedItem)] = this.RowViewModel.SourceRow;
+            this.targetParameters[nameof(this.SelectedItem)] = this.RowViewModel.TargetRow;
+            this.sourceCorrespondance = SelectedItemCardViewModel.GetCorrespondances(this.RowViewModel.SourceRow);
+            this.targetCorrespondance = SelectedItemCardViewModel.GetCorrespondances(this.RowViewModel.TargetRow);
+        }
+    }
+}

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RequirementSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RequirementSelectedItem.razor
@@ -22,5 +22,9 @@
 <AppKeyValue Key="Justification" Value="@(this.RowViewModel.Justification)"/>
 <AppKeyValues Key="Derivation from" Items="@(this.RowViewModel.DerivesFrom)"/>
 <AppKeyValues Key="Derivation to" Items="@(this.RowViewModel.DerivesTo)"/>
+<AppKeyValues Key="Traces" Items="@(this.RowViewModel.Traces)"/>
+<AppKeyValues Key="Traced by" Items="@(this.RowViewModel.TracedBy)"/>
+<AppKeyValues Key="Satisfied by function(s)" Items="@(this.RowViewModel.SatisfyByFunction)"/>
+<AppKeyValues Key="Satisfied by product(s)" Items="@(this.RowViewModel.SatisfyByProduct)"/>
 <AppKeyValues Key="Parametric Constraints" Items="@(this.RowViewModel.ParametricConstraints)"/>
 <AppKeyValues Key="Associated Categories" Items="@(this.RowViewModel.Categories)"/>

--- a/UI_DSM.Client/Components/App/ValuesVisualizer/CompoundValuesVisualizer.razor
+++ b/UI_DSM.Client/Components/App/ValuesVisualizer/CompoundValuesVisualizer.razor
@@ -1,0 +1,40 @@
+﻿<!--------------------------------------------------------------------------------------------------------
+// CompoundValuesVisualizer.razor
+// Copyright (c) 2022 RHEA System S.A.
+// 
+// Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+// This file is part of UI-DSM. 
+// The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+// The UI-DSM application is provided to the community under the Apache License 2.0.
+-------------------------------------------------------------------------------------------------------->
+@using UI_DSM.Client.Extensions
+@using CDP4Common.SiteDirectoryData
+@inherits ValuesVisualizer
+
+<div>
+	@if (this.State != null)
+	{
+		<span>@this.State.Name : </span>
+	}
+	
+	@{ 
+		var compound = (CompoundParameterType)this.Parameter.ParameterType;
+			@for (var componentIndex = 0; componentIndex < compound.Component.Count; componentIndex++)
+			{
+				var currentComponent = compound.Component[componentIndex];
+				<div>
+					<span>@currentComponent.ShortName : </span>
+					<span>@this.Parameter.GetParameterValue(this.Option, this.State, componentIndex)
+						@if (currentComponent.Scale != null)
+						{
+							<span> (@currentComponent.Scale.ShortName)</span>
+						}
+					</span>
+				</div>
+
+			}
+	}
+	
+</div>

--- a/UI_DSM.Client/Components/App/ValuesVisualizer/ScalarValuesVisualizer.razor
+++ b/UI_DSM.Client/Components/App/ValuesVisualizer/ScalarValuesVisualizer.razor
@@ -1,5 +1,5 @@
 ﻿<!--------------------------------------------------------------------------------------------------------
-// PortSelectedItem.razor
+// ScalarValuesVisualizer.razor
 // Copyright (c) 2022 RHEA System S.A.
 // 
 // Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
@@ -9,8 +9,14 @@
 // 
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
-@inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.PortRowViewModel>
-<AppKeyValue Key="Name" Value="@(this.RowViewModel.Id)" />
-<AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)" />
-<AppKeyValue Key="Product Container" Value="@(this.RowViewModel.Container)" />
-<AppKeyValue Key="Interface End" Value="@(this.RowViewModel.InterfaceEnd)" />
+@using UI_DSM.Client.Extensions
+@inherits ValuesVisualizer
+
+<div>
+	@if (this.State != null)
+	{
+		<span>@this.State.Name : </span>
+	}
+	
+	@this.Parameter.GetParameterValue(this.Option, this.State)
+</div>

--- a/UI_DSM.Client/Components/App/ValuesVisualizer/ValuesVisualizer.razor
+++ b/UI_DSM.Client/Components/App/ValuesVisualizer/ValuesVisualizer.razor
@@ -1,5 +1,5 @@
 ﻿<!--------------------------------------------------------------------------------------------------------
-// PortSelectedItem.razor
+// ValuesVisualizer.razor
 // Copyright (c) 2022 RHEA System S.A.
 // 
 // Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
@@ -9,8 +9,3 @@
 // 
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
-@inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.PortRowViewModel>
-<AppKeyValue Key="Name" Value="@(this.RowViewModel.Id)" />
-<AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)" />
-<AppKeyValue Key="Product Container" Value="@(this.RowViewModel.Container)" />
-<AppKeyValue Key="Interface End" Value="@(this.RowViewModel.InterfaceEnd)" />

--- a/UI_DSM.Client/Components/App/ValuesVisualizer/ValuesVisualizer.razor.cs
+++ b/UI_DSM.Client/Components/App/ValuesVisualizer/ValuesVisualizer.razor.cs
@@ -1,0 +1,44 @@
+﻿// --------------------------------------------------------------------------------------------------------
+// <copyright file="ValuesVisualizer.razor.cs" company="RHEA System S.A.">
+//  Copyright (c) 2022 RHEA System S.A.
+// 
+//  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+//  This file is part of UI-DSM.
+//  The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+//  The UI-DSM application is provided to the community under the Apache License 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------
+
+namespace UI_DSM.Client.Components.App.ValuesVisualizer
+{
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    ///     Base component for <see cref="ParameterType" /> values visualizer
+    /// </summary>
+    public abstract partial class ValuesVisualizer
+    {
+        /// <summary>
+        ///     The <see cref="ParameterOrOverrideBase" />
+        /// </summary>
+        [Parameter]
+        public ParameterOrOverrideBase Parameter { get; set; }
+
+        /// <summary>
+        ///     The <see cref="Option" />
+        /// </summary>
+        [Parameter]
+        public Option Option { get; set; }
+
+        /// <summary>
+        ///     The <see cref="ActualFiniteState" />
+        /// </summary>
+        [Parameter]
+        public ActualFiniteState State { get; set; }
+    }
+}

--- a/UI_DSM.Client/Components/NormalUser/Views/ElementBreakdownStructureView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/ElementBreakdownStructureView.razor.cs
@@ -131,7 +131,7 @@ namespace UI_DSM.Client.Components.NormalUser.Views
                     .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
 
                 this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.OptionChooserViewModel.SelectedOption)
-                    .Subscribe(_ => this.InvokeAsync(this.OnRowFilteringClose)));
+                    .Subscribe(_ => this.InvokeAsync(this.OnOptionSelectionClose)));
 
                 this.HideColumnsAtStart();
 
@@ -182,6 +182,23 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         {
             this.ViewModel.FilterRows(this.ViewModel.FilterViewModel.GetSelectedFilters());
             return this.HasChanged();
+        }
+
+        /// <summary>
+        ///     Handles the change of <see cref="Option" />
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        private Task OnOptionSelectionClose()
+        {
+            this.ViewModel.OptionChanged();
+
+            if (this.ViewModel.SelectedElement is ElementBaseRowViewModel row)
+            {
+                this.SelectRow(null);
+                this.SelectRow(row);
+            }
+
+            return this.OnRowFilteringClose();
         }
     }
 }

--- a/UI_DSM.Client/Extensions/ThingExtension.cs
+++ b/UI_DSM.Client/Extensions/ThingExtension.cs
@@ -46,42 +46,42 @@ namespace UI_DSM.Client.Extensions
         /// <summary>
         ///     The name of the satisfy <see cref="Category" />
         /// </summary>
-        public static string SatisfyCategoryName = "satisfies";
+        public const string SatisfyCategoryName = "satisfies";
 
         /// <summary>
         ///     The name of the implement <see cref="Category" />
         /// </summary>
-        public static string ImplementCategoryName = "implements";
+        public const string ImplementCategoryName = "implements";
 
         /// <summary>
         ///     The name of the derive <see cref="Category" />
         /// </summary>
-        public static string DeriveCategoryName = "derives";
+        public const string DeriveCategoryName = "derives";
 
         /// <summary>
         ///     The name of the function <see cref="Category" />
         /// </summary>
-        public static string FunctionCategoryName = "functions";
+        public const string FunctionCategoryName = "functions";
 
         /// <summary>
         ///     The name of the product <see cref="Category" />
         /// </summary>
-        public static string ProductCategoryName = "products";
+        public const string ProductCategoryName = "products";
 
         /// <summary>
         ///     The name of the port <see cref="Category" />
         /// </summary>
-        public static string PortCategoryName = "ports";
+        public const string PortCategoryName = "ports";
 
         /// <summary>
         ///     The name of the interface <see cref="Category" />
         /// </summary>
-        public static string InterfaceCategoryName = "interfaces";
+        public const string InterfaceCategoryName = "interfaces";
         
         /// <summary>
         ///     The name of the interface <see cref="Category" />
         /// </summary>
-        public static string TraceCategoryName = "trace";
+        public const string TraceCategoryName = "trace";
 
         /// <summary>
         ///     Gets the value of a certain parameter

--- a/UI_DSM.Client/Extensions/ThingExtension.cs
+++ b/UI_DSM.Client/Extensions/ThingExtension.cs
@@ -16,8 +16,7 @@ namespace UI_DSM.Client.Extensions
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
-
-    using DynamicData;
+    using CDP4Common.Types;
 
     /// <summary>
     ///     Extension class for <see cref="Thing" />
@@ -43,6 +42,46 @@ namespace UI_DSM.Client.Extensions
         {
             "equipment"
         };
+
+        /// <summary>
+        ///     The name of the satisfy <see cref="Category" />
+        /// </summary>
+        public static string SatisfyCategoryName = "satisfies";
+
+        /// <summary>
+        ///     The name of the implement <see cref="Category" />
+        /// </summary>
+        public static string ImplementCategoryName = "implements";
+
+        /// <summary>
+        ///     The name of the derive <see cref="Category" />
+        /// </summary>
+        public static string DeriveCategoryName = "derives";
+
+        /// <summary>
+        ///     The name of the function <see cref="Category" />
+        /// </summary>
+        public static string FunctionCategoryName = "functions";
+
+        /// <summary>
+        ///     The name of the product <see cref="Category" />
+        /// </summary>
+        public static string ProductCategoryName = "products";
+
+        /// <summary>
+        ///     The name of the port <see cref="Category" />
+        /// </summary>
+        public static string PortCategoryName = "ports";
+
+        /// <summary>
+        ///     The name of the interface <see cref="Category" />
+        /// </summary>
+        public static string InterfaceCategoryName = "interfaces";
+        
+        /// <summary>
+        ///     The name of the interface <see cref="Category" />
+        /// </summary>
+        public static string TraceCategoryName = "trace";
 
         /// <summary>
         ///     Gets the value of a certain parameter
@@ -278,7 +317,7 @@ namespace UI_DSM.Client.Extensions
         /// <returns>The asserts</returns>
         public static bool IsProduct(this ElementBase elementBase)
         {
-            return elementBase.IsCategorizedBy("products");
+            return elementBase.IsCategorizedBy(ProductCategoryName);
         }
 
         /// <summary>
@@ -288,7 +327,7 @@ namespace UI_DSM.Client.Extensions
         /// <returns>The asserts</returns>
         public static bool IsPort(this ElementBase elementBase)
         {
-            return elementBase is ElementUsage && elementBase.IsCategorizedBy("ports");
+            return elementBase is ElementUsage && elementBase.IsCategorizedBy(PortCategoryName);
         }
 
         /// <summary>
@@ -298,7 +337,7 @@ namespace UI_DSM.Client.Extensions
         /// <returns>The asserts</returns>
         public static bool IsFunction(this ElementBase elementDefinition)
         {
-            return elementDefinition.IsCategorizedBy("functions");
+            return elementDefinition.IsCategorizedBy(FunctionCategoryName);
         }
 
         /// <summary>
@@ -322,35 +361,6 @@ namespace UI_DSM.Client.Extensions
         }
 
         /// <summary>
-        ///     Gets a collection of all <see cref="Parameter" />s name with the associated value of an
-        ///     <see cref="ElementBase" />
-        /// </summary>
-        /// <param name="elementBase">The <see cref="ElementBase" /></param>
-        /// <param name="option">The <see cref="Option" /></param>
-        /// <param name="state">The <see cref="ActualFiniteState" /></param>
-        /// <returns>The collection of pair</returns>
-        public static List<(string, string)> GetAllParameterValues(this ElementBase elementBase, Option option, ActualFiniteState state)
-        {
-            var parameterOrOverride = new List<ParameterOrOverrideBase>();
-
-            switch (elementBase)
-            {
-                case ElementDefinition elementDefinition:
-                    parameterOrOverride.AddRange(elementDefinition.Parameter);
-                    break;
-                case ElementUsage elementUsage:
-                    parameterOrOverride.Add(elementUsage.ParameterOverride);
-
-                    parameterOrOverride.Add(elementUsage.ElementDefinition.Parameter.Where(x =>
-                        elementUsage.ParameterOverride.All(po => po.Parameter.Iid != x.Iid)));
-
-                    break;
-            }
-
-            return parameterOrOverride.Select(parameter => (parameter.ParameterType.Name, parameter.GetParameterValue(option, state))).ToList();
-        }
-
-        /// <summary>
         ///     Gets the name of the <see cref="Thing.Container" /> if the current <see cref="ElementBase" /> is an
         ///     <see cref="ElementUsage" />
         /// </summary>
@@ -359,6 +369,30 @@ namespace UI_DSM.Client.Extensions
         public static string GetElementContainer(this ElementBase element)
         {
             return element.GetContainerOfType<ElementDefinition>()?.Name ?? "-";
+        }
+
+        /// <summary>
+        ///     Get all <see cref="ParameterOrOverrideBase" /> contained into an <see cref="ElementBase" />
+        /// </summary>
+        /// <param name="element">The <see cref="ElementBase" /></param>
+        /// <returns>A collection of <see cref="ParameterOrOverrideBase" /></returns>
+        public static List<ParameterOrOverrideBase> GetAllParameters(this ElementBase element)
+        {
+            switch (element)
+            {
+                case ElementDefinition elementDefinition:
+                    return elementDefinition.Parameter.ToList<ParameterOrOverrideBase>();
+                case ElementUsage elementUsage:
+                {
+                    var parameters = elementUsage.ElementDefinition.GetAllParameters();
+                    var parametersOverride = elementUsage.ParameterOverride;
+                    parameters.RemoveAll(p => parametersOverride.Any(x => x.Parameter.Iid == p.Iid));
+                    parameters.AddRange(parametersOverride);
+                    return parameters;
+                }
+                default:
+                    return new List<ParameterOrOverrideBase>();
+            }
         }
 
         /// <summary>
@@ -389,7 +423,7 @@ namespace UI_DSM.Client.Extensions
         /// <returns>True if the <see cref="BinaryRelationship" /> is an Interface</returns>
         public static bool IsInterface(this BinaryRelationship relationShip)
         {
-            return relationShip.IsCategorizedBy("interfaces")
+            return relationShip.IsCategorizedBy(InterfaceCategoryName)
                    && relationShip.Target is ElementUsage targetUsage
                    && targetUsage.IsPort()
                    && relationShip.Source is ElementUsage sourceUsage
@@ -402,10 +436,29 @@ namespace UI_DSM.Client.Extensions
         /// <param name="parameter">The <see cref="ParameterOrOverrideBase" /></param>
         /// <param name="option">The <see cref="Option" /></param>
         /// <param name="state">The <see cref="ActualFiniteState" /></param>
+        /// <param name="index">The index inside the <see cref="ValueArray{T}" /></param>
         /// <returns>The parameter value</returns>
-        public static string GetParameterValue(this ParameterOrOverrideBase parameter, Option option, ActualFiniteState state)
+        public static string GetParameterValue(this ParameterOrOverrideBase parameter, Option option, ActualFiniteState state, int index = 0)
+        {
+            return parameter.GetParameterValueArray(option, state)[index];
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="ValueArray{T}" /> of a <see cref="ParameterOrOverrideBase" />
+        /// </summary>
+        /// <param name="parameter">The <see cref="ParameterOrOverrideBase" /></param>
+        /// <param name="option">The <see cref="Option" /></param>
+        /// <param name="state">The <see cref="ActualFiniteState" /></param>
+        /// <returns>The <see cref="ValueArray{T}" /> value</returns>
+        public static ValueArray<string> GetParameterValueArray(this ParameterOrOverrideBase parameter, Option option, ActualFiniteState state)
         {
             var optionToQuery = parameter.IsOptionDependent ? option : null;
+
+            if (optionToQuery == null && parameter.IsOptionDependent)
+            {
+                optionToQuery = parameter.ValueSets.First(x => x.ActualOption != null).ActualOption;
+            }
+
             ActualFiniteState stateToQuery = null;
 
             if (parameter.StateDependence != null)
@@ -415,7 +468,7 @@ namespace UI_DSM.Client.Extensions
                     : parameter.StateDependence.ActualState.FirstOrDefault();
             }
 
-            return parameter.QueryParameterBaseValueSet(optionToQuery, stateToQuery).ActualValue.First();
+            return parameter.QueryParameterBaseValueSet(optionToQuery, stateToQuery).ActualValue;
         }
 
         /// <summary>
@@ -462,7 +515,7 @@ namespace UI_DSM.Client.Extensions
                 return new List<ElementBase>();
             }
 
-            var relationShips = function.QueryRelationships("implements");
+            var relationShips = function.QueryRelationships(ImplementCategoryName);
 
             return relationShips.Where(x => x.Source is ElementBase elementBase && elementBase.IsProduct())
                 .Select(x => x.Source as ElementBase).ToList();
@@ -565,7 +618,7 @@ namespace UI_DSM.Client.Extensions
         {
             return thing.GetAllCategories().Any(x => !x.IsDeprecated &&
                                                      categories.Any(cat => string.Equals(x.Name, cat, StringComparison.InvariantCultureIgnoreCase)
-                                                     || string.Equals(x.ShortName, cat, StringComparison.InvariantCultureIgnoreCase)));
+                                                                           || string.Equals(x.ShortName, cat, StringComparison.InvariantCultureIgnoreCase)));
         }
 
         /// <summary>

--- a/UI_DSM.Client/Pages/NormalUser/ReviewTaskPage/ReviewTaskPage.razor
+++ b/UI_DSM.Client/Pages/NormalUser/ReviewTaskPage/ReviewTaskPage.razor
@@ -87,8 +87,8 @@
 							</BodyTemplate>
 						</DxDropDown>
 
-						@if (this.ViewModel.Participant.IsAllowedTo(AccessRight.ReviewTask))
-
+						@if (this.ViewModel.Participant.IsAllowedTo(AccessRight.ReviewTask) 
+						     && this.ViewModel.ReviewTask.IsAssignedTo.Any(x => x.Id == this.ViewModel.Participant.Id))
 						{
 							@if (this.ViewModel.ReviewTask.Status == StatusKind.Open)
 							{

--- a/UI_DSM.Client/ViewModels/App/SelectedItemCard/SelectedItemCardViewModel.cs
+++ b/UI_DSM.Client/ViewModels/App/SelectedItemCard/SelectedItemCardViewModel.cs
@@ -80,6 +80,18 @@ namespace UI_DSM.Client.ViewModels.App.SelectedItemCard
         }
 
         /// <summary>
+        ///     Gets the <see cref="Tuple" /> to have the correct component type and label for a
+        ///     <see cref="IHaveAnnotatableItemRowViewModel" />
+        /// </summary>
+        /// <param name="rowViewModel">A <see cref="IHaveAnnotatableItemRowViewModel" /></param>
+        /// <returns>The correspondance</returns>
+        public static Tuple<Type, string> GetCorrespondances(IHaveAnnotatableItemRowViewModel rowViewModel)
+        {
+            var rowViewModelType = rowViewModel.GetType();
+            return Correspondances.ContainsKey(rowViewModelType) ? Correspondances[rowViewModelType] : null;
+        }
+
+        /// <summary>
         ///     Gets the correct <see cref="Type" /> component
         /// </summary>
         /// <returns>The <see cref="Type" /></returns>

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ElementBreakdownStructureViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ElementBreakdownStructureViewViewModel.cs
@@ -157,6 +157,22 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         }
 
         /// <summary>
+        ///     Handle the change of <see cref="Option" />
+        /// </summary>
+        public void OptionChanged()
+        {
+            foreach (var elementBaseRowViewModel in this.TopElement)
+            {
+                elementBaseRowViewModel.UpdateOption(this.OptionChooserViewModel.SelectedOption);
+            }
+
+            foreach (var elementBaseRowViewModel in this.AllRows)
+            {
+                elementBaseRowViewModel.UpdateOption(this.OptionChooserViewModel.SelectedOption);
+            }
+        }
+
+        /// <summary>
         ///     Initializes the filters criteria for rows
         /// </summary>
         protected void InitializesFilter<T>(string categoryNameFiltering) where T : ElementBaseRowViewModel
@@ -183,8 +199,8 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
                                 || x.AllSuperCategories()
                                     .Any(cat => !cat.IsDeprecated && string.Equals(cat.Name, categoryNameFiltering, StringComparison.InvariantCultureIgnoreCase)))
                     .DistinctBy(x => x.Iid))
-                .OrderBy(x => x.Name)
-                .ToList();
+                    .OrderBy(x => x.Name)
+                    .ToList();
 
             availableRowFilters.Add(new FilterModel
             {

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/FunctionalBreakdownStructureViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/FunctionalBreakdownStructureViewViewModel.cs
@@ -106,11 +106,6 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
                                      row.Thing.GetAppliedCategories().Any(thingCat => thingCat.Iid == cat.DefinedThing.Iid)));
 
                 row.IsVisible &= !row.HasOptionExcluded(selectedOption);
-
-                if (row is FunctionRowViewModel function)
-                {
-                    function.UpdateCostValues(selectedOption);
-                }
             }
         }
     }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/FunctionalTraceabilityToProductViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/FunctionalTraceabilityToProductViewViewModel.cs
@@ -48,7 +48,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <summary>
         ///     The name of the category
         /// </summary>
-        protected override string TraceCategoryName => "implements";
+        protected override string TraceCategoryName => ThingExtension.ImplementCategoryName;
 
         /// <summary>
         ///     Apply a filtering on rows
@@ -110,10 +110,10 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
             
             var reviewItemsForRelationships = reviewItems.Where(x => relationships.Any(rel => x.ThingId == rel.Iid)).ToList();
 
+            this.TraceabilityTableViewModel.InitializeProperties(rows, columns);
             this.PopulateRelationships(rows, columns, reviewItemsForRelationships);
             InitializesFilterForElementBaseRows(this.RowsFilterViewModel, rows.OfType<ProductRowViewModel>());
             InitializesFilterForElementBaseRows(this.ColumnsFilterViewModel, columns.OfType<FunctionRowViewModel>());
-            this.TraceabilityTableViewModel.InitializeProperties(rows, columns);
         }
     }
 }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/HaveTraceabilityTableViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/HaveTraceabilityTableViewModel.cs
@@ -337,7 +337,9 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
                 }
 
                 this.AvailableRelationships[rowId][columnId] =
-                    new RelationshipRowViewModel(relationship, relationshipReviewItems.FirstOrDefault(x => x.ThingId == relationship.Iid));
+                    new RelationshipRowViewModel(relationship, relationshipReviewItems.FirstOrDefault(x => x.ThingId == relationship.Iid)
+                    , this.TraceabilityTableViewModel.Rows.First(x => x.ThingId == rowId), 
+                    this.TraceabilityTableViewModel.Columns.First(x => x.ThingId == columnId));
             }
         }
 

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IElementBreakdownStructureViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IElementBreakdownStructureViewViewModel.cs
@@ -14,6 +14,7 @@
 namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
 {
     using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
 
     using UI_DSM.Client.Model;
     using UI_DSM.Client.ViewModels.App.Filter;
@@ -66,5 +67,10 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// </summary>
         /// <param name="selectedFilters">The selected filters</param>
         void FilterRows(IReadOnlyDictionary<ClassKind, List<FilterRow>> selectedFilters);
+
+        /// <summary>
+        ///     Handle the change of <see cref="Option" />
+        /// </summary>
+        void OptionChanged();
     }
 }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IProductBreakdownStructureViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IProductBreakdownStructureViewViewModel.cs
@@ -18,6 +18,5 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
     /// </summary>
     public interface IProductBreakdownStructureViewViewModel : IElementBreakdownStructureViewViewModel
     {
-        
     }
 }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/InterfaceViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/InterfaceViewViewModel.cs
@@ -218,7 +218,9 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
                 .Select(x => new ProductRowViewModel(x, reviewItems.FirstOrDefault(ri => ri.ThingId == x.Iid))));
 
             this.allInterfaces = new List<InterfaceRowViewModel>(interfaces
-                .Select(x => new InterfaceRowViewModel(x, reviewItems.FirstOrDefault(ri => ri.ThingId == x.Iid))));
+                .Select(x => new InterfaceRowViewModel(x, reviewItems.FirstOrDefault(ri => ri.ThingId == x.Iid), 
+                    this.allPorts.First(source => source.ThingId == x.Source.Iid),
+                    this.allPorts.First(target => target.ThingId == x.Target.Iid))));
 
             this.filteredProducts = new List<ProductRowViewModel>(this.allProducts.OrderBy(x => x.Thing.Name));
             this.Interfaces = new List<InterfaceRowViewModel>(this.allInterfaces.OrderBy(x => x.Id));

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ProductBreakdownStructureViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ProductBreakdownStructureViewViewModel.cs
@@ -105,11 +105,6 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
                                      row.Thing.GetAppliedCategories().Any(thingCat => thingCat.Iid == cat.DefinedThing.Iid)));
 
                 row.IsVisible &= !row.HasOptionExcluded(selectedOption);
-
-                if (row is ProductRowViewModel product)
-                {
-                    product.UpdateCostValue(selectedOption);
-                }
             }
         }
     }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewViewModel.cs
@@ -48,7 +48,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <summary>
         ///     The name of the category
         /// </summary>
-        protected override string TraceCategoryName => "satisfies";
+        protected override string TraceCategoryName => ThingExtension.SatisfyCategoryName;
 
         /// <summary>
         ///     Apply a filtering on rows
@@ -102,10 +102,10 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
 
             var reviewItemsForRelationships = reviewItems.Where(x => relationships.Any(rel => x.ThingId == rel.Iid)).ToList();
 
+            this.TraceabilityTableViewModel.InitializeProperties(rows, columns);
             this.PopulateRelationships(rows, columns, reviewItemsForRelationships);
             InitializesFilterForElementBaseRows(this.RowsFilterViewModel, rows.OfType<FunctionRowViewModel>());
             InitializesFilterForRequirementRows(this.ColumnsFilterViewModel, columns.OfType<RequirementRowViewModel>());
-            this.TraceabilityTableViewModel.InitializeProperties(rows, columns);
         }
 
         /// <summary>

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToProductViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToProductViewViewModel.cs
@@ -48,7 +48,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <summary>
         ///     The name of the category
         /// </summary>
-        protected override string TraceCategoryName => "satisfies";
+        protected override string TraceCategoryName => ThingExtension.SatisfyCategoryName;
 
         /// <summary>
         ///     Apply a filtering on rows
@@ -111,10 +111,10 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
 
             var reviewItemsForRelationships = reviewItems.Where(x => relationships.Any(rel => x.ThingId == rel.Iid)).ToList();
 
+            this.TraceabilityTableViewModel.InitializeProperties(rows, columns);
             this.PopulateRelationships(rows, columns, reviewItemsForRelationships);
             InitializesFilterForElementBaseRows(this.RowsFilterViewModel, rows.OfType<ProductRowViewModel>());
             InitializesFilterForRequirementRows(this.ColumnsFilterViewModel, columns.OfType<RequirementRowViewModel>());
-            this.TraceabilityTableViewModel.InitializeProperties(rows, columns);
         }
     }
 }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToRequirementViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToRequirementViewViewModel.cs
@@ -48,7 +48,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <summary>
         ///     The name of the category
         /// </summary>
-        protected override string TraceCategoryName => "trace";
+        protected override string TraceCategoryName => ThingExtension.TraceCategoryName;
 
         /// <summary>
         ///     Initialize this view model properties
@@ -86,10 +86,10 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
 
             var reviewItemsForRelationships = reviewItems.Where(x => relationships.Any(rel => x.ThingId == rel.Iid)).ToList();
 
+            this.TraceabilityTableViewModel.InitializeProperties(rows, columns);
             this.PopulateRelationships(rows, columns, reviewItemsForRelationships);
             InitializesFilterForRequirementRows(this.RowsFilterViewModel, rows.OfType<RequirementRowViewModel>());
             InitializesFilterForRequirementRows(this.ColumnsFilterViewModel, columns.OfType<RequirementRowViewModel>());
-            this.TraceabilityTableViewModel.InitializeProperties(rows, columns);
         }
 
         /// <summary>

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/ElementBaseRowViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/ElementBaseRowViewModel.cs
@@ -61,9 +61,9 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         public string CommaCategories { get; private set; }
 
         /// <summary>
-        ///     A collection of pair of <see cref="string" /> to identify the <see cref="Parameter" /> name and value
+        ///     The selected <see cref="Option" /> for displaying values
         /// </summary>
-        public List<(string, string)> ParameterValues { get; private set; }
+        public Option CurrentOption { get; private set; }
 
         /// <summary>
         ///     The name of the container of the <see cref="ElementBase" />
@@ -86,6 +86,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         public override string Id => this.Thing.Name;
 
         /// <summary>
+        ///     The collection of <see cref="ParameterOrOverrideBase" />
+        /// </summary>
+        public List<ParameterOrOverrideBase> Parameters { get; private set; }
+
+        /// <summary>
         ///     Verifies that the current <see cref="ElementBase" /> has the current <see cref="Option" /> has excluded
         /// </summary>
         /// <param name="option">The <see cref="Option" /></param>
@@ -96,13 +101,22 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         }
 
         /// <summary>
+        ///     Updates the <see cref="CurrentOption" /> property
+        /// </summary>
+        /// <param name="selectedOption">The new <see cref="Option" /></param>
+        public virtual void UpdateOption(Option selectedOption)
+        {
+            this.CurrentOption = selectedOption;
+        }
+
+        /// <summary>
         ///     Initializes this row view model properties
         /// </summary>
         private void InitializesProperties()
         {
-            this.ParameterValues = this.Thing.GetAllParameterValues(null, null);
             this.ElementDefinitionId = this.Thing is ElementUsage usage ? usage.ElementDefinition.Iid : this.ThingId;
             this.CommaCategories = this.Categories.AsCommaSeparated();
+            this.Parameters = this.Thing.GetAllParameters().OrderBy(x => x.ParameterType.Name).ToList();
         }
     }
 }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/FunctionRowViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/FunctionRowViewModel.cs
@@ -13,6 +13,7 @@
 
 namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
 {
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
 
     using UI_DSM.Client.Extensions;
@@ -54,17 +55,38 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         public List<(string, string)> LinkedCostValues { get; private set; } = new();
 
         /// <summary>
+        ///     The names of <see cref="Requirement"/> that are satisfied by the function
+        /// </summary>
+        public IEnumerable<string> SatisfiedRequirements => this.Thing.GetRelatedThingsName(ThingExtension.SatisfyCategoryName, ClassKind.Requirement, 
+            true, false);
+
+        /// <summary>
+        ///     The names of products that implements the function
+        /// </summary>
+        public IEnumerable<string> ProductsImplement => this.Thing.GetRelatedThingsName(ThingExtension.ImplementCategoryName, ClassKind.ElementUsage,
+            ThingExtension.ProductCategoryName, false, false);
+
+        /// <summary>
+        ///     Updates the <see cref="ElementBaseRowViewModel.CurrentOption" /> property
+        /// </summary>
+        /// <param name="selectedOption">The new <see cref="Option" /></param>
+        public override void UpdateOption(Option selectedOption)
+        {
+            base.UpdateOption(selectedOption);
+            this.UpdateCostValues();
+        }
+
+        /// <summary>
         ///     Updates the collection of <see cref="LinkedCostValues" /> based on an option
         /// </summary>
-        /// <param name="option">The <see cref="Option" /></param>
-        public void UpdateCostValues(Option option)
+        private void UpdateCostValues()
         {
             var linkedProducts = this.Thing.GetLinkedProducts();
             this.LinkedCostValues.Clear();
 
             foreach (var product in linkedProducts.OrderBy(x => x.Name))
             {
-                this.LinkedCostValues.Add(product.TryGetParameterValue("cost", null, null, out var cost)
+                this.LinkedCostValues.Add(product.TryGetParameterValue("cost", this.CurrentOption, null, out var cost)
                     ? (product.Name, cost)
                     : (product.Name, "-"));
             }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/InterfaceRowViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/InterfaceRowViewModel.cs
@@ -22,7 +22,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
     /// <summary>
     ///     Row view model to display content for a <see cref="BinaryRelationship" /> that are interface
     /// </summary>
-    public class InterfaceRowViewModel : HaveThingRowViewModel<BinaryRelationship>, IBelongsToInterfaceView
+    public class InterfaceRowViewModel : RelationshipRowViewModel, IBelongsToInterfaceView
     {
         /// <summary>
         ///     The source of the <see cref="BinaryRelationship" />
@@ -49,7 +49,10 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         /// </summary>
         /// <param name="thing">The <see cref="BinaryRelationship" /></param>
         /// <param name="reviewItem">The associated <see cref="HaveThingRowViewModel{TThing}.ReviewItem" /></param>
-        public InterfaceRowViewModel(BinaryRelationship thing, ReviewItem reviewItem) : base(thing, reviewItem)
+        /// <param name="sourceRow">The <see cref="IHaveThingRowViewModel" /> for the source</param>
+        /// <param name="targetRow">The <see cref="IHaveThingRowViewModel" /> for the target</param>
+        public InterfaceRowViewModel(BinaryRelationship thing, ReviewItem reviewItem, 
+            IHaveThingRowViewModel sourceRow, IHaveThingRowViewModel targetRow) : base(thing, reviewItem, sourceRow, targetRow)
         {
             this.InitializesProperties();
         }
@@ -65,16 +68,6 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         public Category NatureCategory => this.Thing.GetAppliedCategories().FirstOrDefault();
 
         /// <summary>
-        ///     The Iid of the source
-        /// </summary>
-        public Guid SourceId => this.source.Iid;
-
-        /// <summary>
-        ///     The Iid of the target
-        /// </summary>
-        public Guid TargetId => this.target.Iid;
-
-        /// <summary>
         ///     The owner of the <see cref="BinaryRelationship" />
         /// </summary>
         public DomainOfExpertise InterfaceOwner => this.Thing.Owner;
@@ -85,29 +78,9 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         public override string Id => this.ComputedName;
 
         /// <summary>
-        ///     The name of the source
-        /// </summary>
-        public string SourceName => this.source?.Name;
-
-        /// <summary>
-        ///     The name of the target
-        /// </summary>
-        public string TargetName => this.target?.Name;
-
-        /// <summary>
         ///     The owner of the interface
         /// </summary>
         public string Owner => this.Thing.GetOwnerShortName();
-
-        /// <summary>
-        ///     The owner of the source
-        /// </summary>
-        public string SourceOwner => this.source.GetOwnerShortName();
-
-        /// <summary>
-        ///     The owner of the target
-        /// </summary>
-        public string TargetOwner => this.target.GetOwnerShortName();
 
         /// <summary>
         ///     The interface end of the Target

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/ProductRowViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/ProductRowViewModel.cs
@@ -13,10 +13,13 @@
 
 namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
 {
+    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
 
     using UI_DSM.Client.Extensions;
     using UI_DSM.Shared.Models;
+
+    using ThingExtension = UI_DSM.Client.Extensions.ThingExtension;
 
     /// <summary>
     ///     Row view model to display content for a <see cref="ElementBase" /> that are Product
@@ -31,6 +34,16 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         public ProductRowViewModel(ElementBase thing, ReviewItem reviewItem) : base(thing, reviewItem)
         {
             this.InitializesProperties();
+        }
+
+        /// <summary>
+        ///     Updates the <see cref="ElementBaseRowViewModel.CurrentOption" /> property
+        /// </summary>
+        /// <param name="selectedOption">The new <see cref="Option" /></param>
+        public override void UpdateOption(Option selectedOption)
+        {
+            base.UpdateOption(selectedOption);
+            this.CostValue = this.Thing.TryGetParameterValue("cost", this.CurrentOption, null, out var retrievedValue) ? retrievedValue : "-";
         }
 
         /// <summary>
@@ -104,6 +117,18 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         public string Nature => null;
 
         /// <summary>
+        ///     The names of <see cref="Requirement"/> that are satisfied by the product
+        /// </summary>
+        public IEnumerable<string> SatisfiedRequirements => this.Thing.GetRelatedThingsName(ThingExtension.SatisfyCategoryName, ClassKind.Requirement, 
+             true, false);
+
+        /// <summary>
+        ///     The names of functions that are implemented by the product
+        /// </summary>
+        public IEnumerable<string> ImplementedFunctions => this.Thing.GetRelatedThingsName(ThingExtension.ImplementCategoryName, ClassKind.ElementUsage,
+            ThingExtension.FunctionCategoryName, true, false);
+
+        /// <summary>
         ///     Compute the <see cref="ComputedId" />
         /// </summary>
         /// <param name="shouldShowTechnology">If should include the technology</param>
@@ -117,15 +142,6 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
             {
                 this.ComputedId = this.Thing.Name;
             }
-        }
-
-        /// <summary>
-        ///     Update the cost value based on an <see cref="Option" />
-        /// </summary>
-        /// <param name="option">The <see cref="Option" /></param>
-        public void UpdateCostValue(Option option)
-        {
-            this.CostValue = this.Thing.TryGetParameterValue("cost", option, null, out var retrievedValue) ? retrievedValue : "-";
         }
 
         /// <summary>

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/RelationshipRowViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/RelationshipRowViewModel.cs
@@ -29,9 +29,24 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         /// </summary>
         /// <param name="thing">The <see cref="BinaryRelationship" /></param>
         /// <param name="reviewItem">The associated <see cref="HaveThingRowViewModel{TThing}.ReviewItem" /></param>
-        public RelationshipRowViewModel(BinaryRelationship thing, ReviewItem reviewItem) : base(thing, reviewItem)
+        /// <param name="sourceRow">The <see cref="IHaveThingRowViewModel" /> for the source</param>
+        /// <param name="targetRow">The <see cref="IHaveThingRowViewModel" /> for the target</param>
+        public RelationshipRowViewModel(BinaryRelationship thing, ReviewItem reviewItem,
+            IHaveThingRowViewModel sourceRow, IHaveThingRowViewModel targetRow) : base(thing, reviewItem)
         {
+            this.SourceRow = sourceRow;
+            this.TargetRow = targetRow;
         }
+
+        /// <summary>
+        ///     The <see cref="IHaveThingRowViewModel" /> for the target
+        /// </summary>
+        public IHaveThingRowViewModel TargetRow { get; }
+
+        /// <summary>
+        ///     The <see cref="IHaveThingRowViewModel" /> for the source
+        /// </summary>
+        public IHaveThingRowViewModel SourceRow { get; }
 
         /// <summary>
         ///     Gets the Id of the current <see cref="RelationshipRowViewModel" />

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/RequirementRowViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/RequirementRowViewModel.cs
@@ -21,6 +21,8 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
     using UI_DSM.Shared.Extensions;
     using UI_DSM.Shared.Models;
 
+    using ThingExtension = UI_DSM.Client.Extensions.ThingExtension;
+
     /// <summary>
     ///     Row view model to display content for a <see cref="Requirement" />
     /// </summary>
@@ -94,7 +96,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         /// <summary>
         ///     The names of the <see cref="Thing" />s from which the <see cref="Requirement" /> derives
         /// </summary>
-        public IEnumerable<string> DerivesFrom => this.Thing.GetRelatedThingsName("derives", ClassKind.Requirement, false);
+        public IEnumerable<string> DerivesFrom => this.Thing.GetRelatedThingsName(ThingExtension.DeriveCategoryName, ClassKind.Requirement, false);
 
         /// <summary>
         ///     The collection of the names of the <see cref="Thing" /> from which the <see cref="Requirement" /> derives separated by a ','
@@ -104,7 +106,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         /// <summary>
         ///     The names of the <see cref="Thing" />s to which the <see cref="Requirement" /> derives
         /// </summary>
-        public IEnumerable<string> DerivesTo => this.Thing.GetRelatedThingsName("derives", ClassKind.Requirement);
+        public IEnumerable<string> DerivesTo => this.Thing.GetRelatedThingsName(ThingExtension.DeriveCategoryName, ClassKind.Requirement);
 
         /// <summary>
         ///     The collection of the names of the <see cref="Thing" /> to which the <see cref="Requirement" /> derives separated by a ','
@@ -114,7 +116,8 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         /// <summary>
         ///     The names of functions that satisfies the <see cref="Requirement" />
         /// </summary>
-        public IEnumerable<string> SatisfyByFunction => this.Thing.GetRelatedThingsName("satisfy", ClassKind.ElementDefinition, "function", false, false);
+        public IEnumerable<string> SatisfyByFunction => this.Thing.GetRelatedThingsName(ThingExtension.SatisfyCategoryName, ClassKind.ElementUsage,
+            ThingExtension.FunctionCategoryName, false, false);
 
         /// <summary>
         ///     The collection of the name of functions that satisfies the <see cref="Requirement" /> separated by a ','
@@ -124,7 +127,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         /// <summary>
         ///     The names of products that satisfies the <see cref="Requirement" />
         /// </summary>
-        public IEnumerable<string> SatisfyByProduct => this.Thing.GetRelatedThingsName("satisfy", ClassKind.ElementDefinition, "product", false, false);
+        public IEnumerable<string> SatisfyByProduct => this.Thing.GetRelatedThingsName(ThingExtension.DeriveCategoryName, ClassKind.ElementUsage, ThingExtension.ProductCategoryName, false, false);
 
         /// <summary>
         ///     The collection of the name of products that satisfies the <see cref="Requirement" /> separated by a ','
@@ -144,7 +147,12 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         /// <summary>
         ///     A collection of name for <see cref="Requirement" />s that trace this <see cref="Requirement" />
         /// </summary>
-        public IEnumerable<string> Traces => this.Thing.GetRelatedThingsName("trace", ClassKind.Requirement);
+        public IEnumerable<string> Traces => this.Thing.GetRelatedThingsName(ThingExtension.TraceCategoryName, ClassKind.Requirement);
+
+        /// <summary>
+        ///     A collection of name for <see cref="Requirement" />s that trace this <see cref="Requirement" />
+        /// </summary>
+        public IEnumerable<string> TracedBy => this.Thing.GetRelatedThingsName(ThingExtension.TraceCategoryName, ClassKind.Requirement, false);
 
         /// <summary>
         ///     Initializes this row view model properties

--- a/UI_DSM.Client/_Imports.razor
+++ b/UI_DSM.Client/_Imports.razor
@@ -35,6 +35,9 @@
 @using UI_DSM.Client.Components.App.AppObjectiveItem
 @using UI_DSM.Client.Components.App.AnnotationLinker
 @using UI_DSM.Client.Components.App.AppBreadCrumb
+@using UI_DSM.Client.Components.App.ParameterValuesVisualizer
+@using UI_DSM.Client.Components.App.ParametersComponent
+@using UI_DSM.Client.Components.App.ValuesVisualizer
 @using UI_DSM.Client.Shared.TopMenu
 @using DevExpress.Blazor
 @using Microsoft.AspNetCore.Authorization

--- a/UI_DSM.Server/Managers/ReviewManager/ReviewManager.cs
+++ b/UI_DSM.Server/Managers/ReviewManager/ReviewManager.cs
@@ -14,6 +14,7 @@
 namespace UI_DSM.Server.Managers.ReviewManager
 {
     using Microsoft.EntityFrameworkCore;
+    
     using UI_DSM.Server.Context;
     using UI_DSM.Server.Extensions;
     using UI_DSM.Server.Managers.ArtifactManager;
@@ -161,6 +162,8 @@ namespace UI_DSM.Server.Managers.ReviewManager
                 .SelectMany(x => x.ReviewItems)
                 .SelectMany(x => x.Annotations)
                 .OfType<Comment>()
+                .ToList()
+                .DistinctBy(x => x.Id)
                 .Count();
 
             return new ComputedProjectProperties

--- a/UI_DSM.Shared/Extensions/ThingExtension.cs
+++ b/UI_DSM.Shared/Extensions/ThingExtension.cs
@@ -15,6 +15,7 @@ namespace UI_DSM.Shared.Extensions
 {
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
 
     /// <summary>
     ///     Extension class for <see cref="Thing" /> object
@@ -45,6 +46,18 @@ namespace UI_DSM.Shared.Extensions
             foreach (var containedThings in things.ToList())
             {
                 things.AddRange(containedThings.QueryReferencedThingsDeep());
+            }
+
+            foreach (var components in things.OfType<CompoundParameterType>()
+                         .ToList().Select(compoundParameterType => compoundParameterType.Component))
+            {
+                things.AddRange(components);
+
+                foreach (ParameterTypeComponent parameterTypeComponent in components)
+                {
+                    things.AddRange(parameterTypeComponent.QueryReferencedThingsDeep()); 
+                    things.AddRange(parameterTypeComponent.QueryContainedThingsDeep()); 
+                }
             }
 
             return things.DistinctById();


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/UI-DSM/pulls) open
- [x] I have verified that I am following the UI-DSM [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/UI-DSM/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #160 

- For selected ElementBase (except Port), all parameters with values (Popup enabled if CompoundParameterType or StateDependency) are shown
- For Function/Product, Satisfy and Implement relationship visible
- For Requirement, Trace relationship visible
- For Relationship (Including Interface), the content of the source/target is visible
<!-- Thanks for contributing to UI-DSM! -->