### PR TITLE
Navigation by double-clicking enabled : Fix #161

### DIFF
--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewTestFixture.cs
@@ -199,6 +199,33 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     Assert.That(renderer.FindComponents<FeatherCheck>(), Has.Count.EqualTo(1));
                     Assert.That(renderer.FindComponents<FeatherMessageCircle>(), Has.Count.EqualTo(1));
                 });
+
+                var runtime = this.context.JSInterop;
+
+                await renderer.Instance.TryNavigateToItem("1");
+                runtime.VerifyInvoke("scrollToElement",1);
+
+                await renderer.Instance.TryNavigateToItem("2");
+                runtime.VerifyInvoke("scrollToElement", 2);
+
+                await renderer.Instance.TryNavigateToItem("3");
+                runtime.VerifyInvoke("scrollToElement", 2);
+
+                await renderer.Instance.TryNavigateToItem(elementUsage.Name);
+                runtime.VerifyInvoke("scrollToElement", 3);
+
+                this.viewModel.TraceabilityTableViewModel.SelectedElement = this.viewModel.TraceabilityTableViewModel.Rows.First();
+
+                await renderer.Instance.TryNavigateToItem($"{elementUsage.Name} -> 2");
+                runtime.VerifyInvoke("scrollToElement", 4);
+
+                await renderer.Instance.TryNavigateToItem("2");
+                runtime.VerifyInvoke("scrollToElement", 5);
+
+                this.viewModel.TraceabilityTableViewModel.SelectedElement = this.viewModel.TraceabilityTableViewModel.Columns.Last();
+
+                await renderer.Instance.TryNavigateToItem(elementUsage.Name);
+                runtime.VerifyInvoke("scrollToElement", 6);
             }
             catch
             {

--- a/UI_DSM.Client/Components/Administration/RoleManagement/RoleCreation.razor
+++ b/UI_DSM.Client/Components/Administration/RoleManagement/RoleCreation.razor
@@ -13,11 +13,12 @@
 @using UI_DSM.Shared.Helpers
 @using UI_DSM.Shared.Wrappers
 
+<CascadingValue Name="PreventValidation" Value="true">
 <EditForm Context="editFormContext" Model="@this.ViewModel.Role" OnValidSubmit="@this.ViewModel.OnValidSubmit">
 	<DataAnnotationsValidator />
 	<DxFormLayout>
 		<DxFormLayoutItem Caption="Role Name:" ColSpanMd="12" >
-				<DxTextBox @bind-Text="@this.ViewModel.Role.RoleName" NullText="Enter the name of the role"/>
+			<DxTextBox @bind-Text="@this.ViewModel.Role.RoleName" NullText="Enter the name of the role"/>
 		</DxFormLayoutItem>
 		<DxFormLayoutItem Caption="Access Rights :" ColSpanMd="12">
 			<DxListBox Data="@AccessRightHelper.GetAccessRights()"
@@ -33,3 +34,4 @@
 		<DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Create" SubmitFormOnClick="true"/>
 	</div>
 </EditForm>
+</CascadingValue>

--- a/UI_DSM.Client/Components/App/AppAccordion/AppAccordion.razor
+++ b/UI_DSM.Client/Components/App/AppAccordion/AppAccordion.razor
@@ -10,8 +10,6 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 
-@namespace AppComponents
-
 <div id="@(this.Id)" class="app-accordion">
 	<button class="app-accordion__button @(this.ButtonClass) @(this.accordionVariant)" @onclick="this.TogglePanel"
 		aria-label="@(this.Label)">
@@ -24,86 +22,3 @@
 		@(this.ChildContent)
 	</div>
 </div>
-
-@code {
-
-	/// <summary>
-	/// The css class to apply to panel
-	/// </summary>
-	private string PanelClass => this.PanelOpen ? "app-accordion__panel--is-open" : null;
-
-	/// <summary>
-	/// The css class to apply to button
-	/// </summary>
-	private string ButtonClass => this.PanelOpen ? "app-accordion__button--is-active" : null;
-
-	/// <summary>
-	/// Different variants on the button, for styling purpose
-	/// </summary>
-	public enum VariantValue
-	{
-		Default,
-		Small,
-		Tiny,
-		Reply
-	}
-
-	/// <summary>
-	/// Gets or sets the <see cref="VariantValue" />
-	/// </summary>
-	[Parameter]
-	public VariantValue Variant { get; set; } = VariantValue.Default;
-
-	/// <summary>
-	/// String value conversion based on <see cref="VariantValue" />
-	/// </summary>
-	private string accordionVariant { get; set; }
-
-	/// <summary>
-	/// Method invoked when the component is ready to start, having received its
-	/// initial parameters from its parent in the render tree.
-	/// </summary>
-	protected override void OnInitialized()
-	{
-		this.accordionVariant = this.Variant switch
-		{
-			VariantValue.Default => "app-accordion__button--default",
-			VariantValue.Small => "app-accordion__button--small",
-			VariantValue.Tiny => "app-accordion__button--tiny",
-			VariantValue.Reply => "app-accordion__button--reply",
-			_ => ""
-		};
-	}
-
-	/// <summary>
-	/// Button label used as aria label and innerhtml
-	/// </summary>
-	[Parameter]
-	public string Label { get; set; }
-
-	/// <summary>
-	/// HTML ID for the app accordion
-	/// </summary>
-	[Parameter]
-	public string Id { get; set; }
-
-	/// <summary>
-	/// HTML child content for the panel
-	/// </summary>
-	[Parameter]
-	public RenderFragment ChildContent { get; set; }
-
-	/// <summary>
-	/// Bool to keep track of the open state of the panel
-	/// </summary>
-	[Parameter]
-	public bool PanelOpen { get; set; } = true;
-
-	/// <summary>
-	/// Method to toggle panel state
-	/// </summary>
-	private void TogglePanel()
-	{
-		this.PanelOpen = !this.PanelOpen;
-	}
-}

--- a/UI_DSM.Client/Components/App/AppAccordion/AppAccordion.razor.cs
+++ b/UI_DSM.Client/Components/App/AppAccordion/AppAccordion.razor.cs
@@ -1,0 +1,115 @@
+﻿// --------------------------------------------------------------------------------------------------------
+// <copyright file="AppAccordion.razor.cs" company="RHEA System S.A.">
+//  Copyright (c) 2022 RHEA System S.A.
+// 
+//  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+//  This file is part of UI-DSM.
+//  The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+//  The UI-DSM application is provided to the community under the Apache License 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------
+
+namespace UI_DSM.Client.Components.App.AppAccordion
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    ///     Component that allow collapsing and expanding data
+    /// </summary>
+    public partial class AppAccordion
+    {
+        /// <summary>
+        ///     Different variants on the button, for styling purpose
+        /// </summary>
+        public enum VariantValue
+        {
+            Default,
+            Small,
+            Tiny,
+            Reply
+        }
+
+        /// <summary>
+        ///     The css class to apply to panel
+        /// </summary>
+        private string PanelClass => this.PanelOpen ? "app-accordion__panel--is-open" : null;
+
+        /// <summary>
+        ///     The css class to apply to button
+        /// </summary>
+        private string ButtonClass => this.PanelOpen ? "app-accordion__button--is-active" : null;
+
+        /// <summary>
+        ///     Gets or sets the <see cref="VariantValue" />
+        /// </summary>
+        [Parameter]
+        public VariantValue Variant { get; set; } = VariantValue.Default;
+
+        /// <summary>
+        ///     String value conversion based on <see cref="VariantValue" />
+        /// </summary>
+        private string accordionVariant { get; set; }
+
+        /// <summary>
+        ///     Button label used as aria label and innerhtml
+        /// </summary>
+        [Parameter]
+        public string Label { get; set; }
+
+        /// <summary>
+        ///     HTML ID for the app accordion
+        /// </summary>
+        [Parameter]
+        public string Id { get; set; }
+
+        /// <summary>
+        ///     HTML child content for the panel
+        /// </summary>
+        [Parameter]
+        public RenderFragment ChildContent { get; set; }
+
+        /// <summary>
+        ///     Bool to keep track of the open state of the panel
+        /// </summary>
+        [Parameter]
+        public bool PanelOpen { get; set; } = true;
+
+        /// <summary>
+        ///     <see cref="EventCallback{TValue}" /> when the <see cref="PanelOpen" /> value changed
+        /// </summary>
+
+        [Parameter]
+        public EventCallback<bool> PanelOpenChanged { get; set; }
+
+        /// <summary>
+        ///     Method invoked when the component is ready to start, having received its
+        ///     initial parameters from its parent in the render tree.
+        /// </summary>
+        protected override void OnInitialized()
+        {
+            this.accordionVariant = this.Variant switch
+            {
+                VariantValue.Default => "app-accordion__button--default",
+                VariantValue.Small => "app-accordion__button--small",
+                VariantValue.Tiny => "app-accordion__button--tiny",
+                VariantValue.Reply => "app-accordion__button--reply",
+                _ => ""
+            };
+        }
+
+        /// <summary>
+        ///     Method to toggle panel state
+        /// </summary>
+        private async Task TogglePanel()
+        {
+            this.PanelOpen = !this.PanelOpen;
+
+            if (this.PanelOpenChanged.HasDelegate)
+            {
+                await this.PanelOpenChanged.InvokeAsync(this.PanelOpen);
+            }
+        }
+    }
+}

--- a/UI_DSM.Client/Components/App/AppKeyValue/AppKeyValue.razor
+++ b/UI_DSM.Client/Components/App/AppKeyValue/AppKeyValue.razor
@@ -9,59 +9,8 @@
 //
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
-@namespace AppComponents
 
-<div class="app-key-value  @(this.componentVariant)">
+<div class="app-key-value @(this.componentVariant)" @ondblclick="() => this.OnDoubleClick(this.Value)">
 	<span class="app-key-value__key">@(this.Key)</span>
 	<span class="app-key-value__value">@(this.Value)</span>
 </div>
-
-@code {
-
-	/// <summary>
-	///     Different variants on the button, for styling purpose
-	/// </summary>
-	public enum VariantValue
-	{
-		Horizontal,
-		Vertical
-	}
-
-	/// <summary>
-	///     Key label name
-	/// </summary>
-	[Parameter]
-	public string Key { get; set; }
-
-	/// <summary>
-	///     Value string
-	/// </summary>
-	[Parameter]
-	public string Value { get; set; }
-
-	/// <summary>
-	///     Gets or sets the <see cref="VariantValue" />
-	/// </summary>
-	[Parameter]
-	public VariantValue Variant { get; set; } = VariantValue.Horizontal;
-
-	/// <summary>
-	///     String value conversion based on <see cref="VariantValue" />
-	/// </summary>
-	private string componentVariant { get; set; }
-
-	/// <summary>
-	///     Method invoked when the component is ready to start, having received its
-	///     initial parameters from its parent in the render tree.
-	/// </summary>
-	protected override void OnInitialized()
-	{
-		this.componentVariant = this.Variant switch
-		{
-			VariantValue.Horizontal => "app-key-value--horizontal",
-			VariantValue.Vertical => "app-key-value--vertical",
-			_ => ""
-			};
-	}
-
-}

--- a/UI_DSM.Client/Components/App/AppKeyValue/AppKeyValue.razor.cs
+++ b/UI_DSM.Client/Components/App/AppKeyValue/AppKeyValue.razor.cs
@@ -1,0 +1,85 @@
+﻿// --------------------------------------------------------------------------------------------------------
+// <copyright file="AppKeyValue.razor.cs" company="RHEA System S.A.">
+//  Copyright (c) 2022 RHEA System S.A.
+// 
+//  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+//  This file is part of UI-DSM.
+//  The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+//  The UI-DSM application is provided to the community under the Apache License 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------
+
+namespace UI_DSM.Client.Components.App.AppKeyValue
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    ///     Component to display a pair of Key-Value
+    /// </summary>
+    public partial class AppKeyValue
+    {
+        /// <summary>
+        ///     Different variants on the button, for styling purpose
+        /// </summary>
+        public enum VariantValue
+        {
+            Horizontal,
+            Vertical
+        }
+
+        /// <summary>
+        ///     Key label name
+        /// </summary>
+        [Parameter]
+        public string Key { get; set; }
+
+        /// <summary>
+        ///     Value string
+        /// </summary>
+        [Parameter]
+        public string Value { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the <see cref="VariantValue" />
+        /// </summary>
+        [Parameter]
+        public VariantValue Variant { get; set; } = VariantValue.Horizontal;
+
+        /// <summary>
+        ///     String value conversion based on <see cref="VariantValue" />
+        /// </summary>
+        private string componentVariant { get; set; }
+
+        /// <summary>
+        ///     The <see cref="EventCallback{TValue}" /> to handle the double click on a property for navigation
+        /// </summary>
+        [Parameter]
+        public EventCallback<string> OnItemDoubleClick { get; set; }
+
+        /// <summary>
+        ///     Method invoked when the component is ready to start, having received its
+        ///     initial parameters from its parent in the render tree.
+        /// </summary>
+        protected override void OnInitialized()
+        {
+            this.componentVariant = this.Variant switch
+            {
+                VariantValue.Horizontal => "app-key-value--horizontal",
+                VariantValue.Vertical => "app-key-value--vertical",
+                _ => ""
+            };
+        }
+
+        /// <summary>
+        ///     Fire the <see cref="OnItemDoubleClick" /> callback
+        /// </summary>
+        /// <param name="propertyName">The name of the double-clicked property</param>
+        /// <returns>A <see cref="Task" /></returns>
+        private Task OnDoubleClick(string propertyName)
+        {
+            return this.OnItemDoubleClick.HasDelegate ? this.InvokeAsync(() => this.OnItemDoubleClick.InvokeAsync(propertyName)) : Task.CompletedTask;
+        }
+    }
+}

--- a/UI_DSM.Client/Components/App/AppKeyValues/AppKeyValues.razor
+++ b/UI_DSM.Client/Components/App/AppKeyValues/AppKeyValues.razor
@@ -9,30 +9,14 @@
 //
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
-@namespace AppComponents
 
 <div class="app-key-values">
-	<AppAccordion Label="@(this.Key)" Variant="AppAccordion.VariantValue.Tiny" PanelOpen="false">
+	<AppAccordion Label="@(this.Key)" Variant="AppAccordion.VariantValue.Tiny" @bind-PanelOpen="@this.IsPanelOpen">
 		<ul class="app-key-values__list">
 			@foreach (var item in this.Items)
 			{
-				<li class="app-key-values__list-item">@item</li>
+				<li class="app-key-values__list-item" @ondblclick="() => this.OnDoubleClick(item)">@item</li>
 			}
 		</ul>
 	</AppAccordion>
 </div>
-
-@code {
-
-	/// <summary>
-	///     Key label name
-	/// </summary>
-	[Parameter]
-	public string Key { get; set; }
-
-	/// <summary>
-	///     Values list
-	/// </summary>
-	[Parameter]
-	public IEnumerable<string> Items { get; set; }
-}

--- a/UI_DSM.Client/Components/App/AppKeyValues/AppKeyValues.razor.cs
+++ b/UI_DSM.Client/Components/App/AppKeyValues/AppKeyValues.razor.cs
@@ -1,0 +1,59 @@
+﻿// --------------------------------------------------------------------------------------------------------
+// <copyright file="AppKeyValues.razor.cs" company="RHEA System S.A.">
+//  Copyright (c) 2022 RHEA System S.A.
+// 
+//  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
+// 
+//  This file is part of UI-DSM.
+//  The UI-DSM web application is used to review an ECSS-E-TM-10-25 model.
+// 
+//  The UI-DSM application is provided to the community under the Apache License 2.0.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------
+
+namespace UI_DSM.Client.Components.App.AppKeyValues
+{
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    ///     Component to display a pair of Key-Value where value is a collection of <see cref="string" />
+    /// </summary>
+    public partial class AppKeyValues
+    {
+        /// <summary>
+        ///     Key label name
+        /// </summary>
+        [Parameter]
+        public string Key { get; set; }
+
+        /// <summary>
+        ///     Values list
+        /// </summary>
+        [Parameter]
+        public IEnumerable<string> Items { get; set; }
+
+        /// <summary>
+        ///     The <see cref="EventCallback{TValue}" /> to handle the double click on a property for navigation
+        /// </summary>
+        [Parameter]
+        public EventCallback<string> OnItemDoubleClick { get; set; }
+
+        /// <summary>
+        ///     Value indicating if the panel is open
+        /// </summary>
+        public bool IsPanelOpen { get; set; }
+
+        /// <summary>
+        ///     Fire the <see cref="OnItemDoubleClick" /> callback
+        /// </summary>
+        /// <param name="propertyName">The name of the double-clicked property</param>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task OnDoubleClick(string propertyName)
+        {
+            if (this.OnItemDoubleClick.HasDelegate)
+            {
+                await this.InvokeAsync(() => this.OnItemDoubleClick.InvokeAsync(propertyName));
+            }
+        }
+    }
+}

--- a/UI_DSM.Client/Components/App/CommentCard/CommentCard.razor
+++ b/UI_DSM.Client/Components/App/CommentCard/CommentCard.razor
@@ -1,4 +1,3 @@
-@using UI_DSM.Shared.Enumerator
 <!--------------------------------------------------------------------------------------------------------
 // CommentCard.razor
 // Copyright (c) 2022 RHEA System S.A.
@@ -10,6 +9,7 @@
 //
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
+@using UI_DSM.Shared.Enumerator
 
 <div class="app-comment">
 	<div class="app-comment__header">
@@ -98,10 +98,10 @@
 	@if (this.ViewModel.LinkedRows.Any())
 	{
 		<div class="app-comment__annotatableItems">
-			<AppAccordion Label="Linked Items" Variant="AppAccordion.VariantValue.Reply" PanelOpen="false">
-				@foreach (var linkedItem in this.ViewModel.LinkedRows.OrderBy(x => x.Id))
+			<AppAccordion Label="Linked Items" Variant="AppAccordion.VariantValue.Reply" @bind-PanelOpen="@this.IsPanelOpen">
+				@foreach (var linkedItem in this.ViewModel.LinkedRows.DistinctBy(x => x.Id).OrderBy(x => x.Id))
 				{
-					<p>@linkedItem.Id</p>
+					<p @ondblclick="() => this.OnDoubleClick(linkedItem.Id)">@linkedItem.Id</p>
 				}
 			</AppAccordion>
 		</div>

--- a/UI_DSM.Client/Components/App/CommentCard/CommentCard.razor.cs
+++ b/UI_DSM.Client/Components/App/CommentCard/CommentCard.razor.cs
@@ -43,6 +43,12 @@ namespace UI_DSM.Client.Components.App.CommentCard
         public ICommentCardViewModel ViewModel { get; set; }
 
         /// <summary>
+        ///     The <see cref="EventCallback{TValue}" /> to handle the double click on a property for navigation
+        /// </summary>
+        [Parameter]
+        public EventCallback<string> OnItemDoubleClick { get; set; }
+
+        /// <summary>
         ///     Value indicating if the component is on update mode
         /// </summary>
         public bool IsOnStatusUpdateMode { get; set; }
@@ -56,6 +62,11 @@ namespace UI_DSM.Client.Components.App.CommentCard
         ///     The unique html id
         /// </summary>
         public string CardUniqueId => $"comment_{this.ViewModel.Comment.Id}";
+
+        /// <summary>
+        ///     Value indicating if the panel is open or not
+        /// </summary>
+        public bool IsPanelOpen { get; set; }
 
         /// <summary>
         ///     Handle the click event of the content edit button
@@ -101,6 +112,16 @@ namespace UI_DSM.Client.Components.App.CommentCard
         private Task OnLinkCallback()
         {
             return this.ViewModel.OnLinkCallback.InvokeAsync(this.ViewModel.Comment);
+        }
+
+        /// <summary>
+        ///     Fire the <see cref="OnItemDoubleClick" /> callback
+        /// </summary>
+        /// <param name="propertyName">The name of the double-clicked property</param>
+        /// <returns>A <see cref="Task" /></returns>
+        private Task OnDoubleClick(string propertyName)
+        {
+            return this.OnItemDoubleClick.HasDelegate ? this.InvokeAsync(() => this.OnItemDoubleClick.InvokeAsync(propertyName)) : Task.CompletedTask;
         }
     }
 }

--- a/UI_DSM.Client/Components/App/Comments/Comments.razor
+++ b/UI_DSM.Client/Components/App/Comments/Comments.razor
@@ -11,6 +11,7 @@
 -------------------------------------------------------------------------------------------------------->
 @using UI_DSM.Shared.Enumerator
 @using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
+
 <AppAccordion Label="Comments">
 	<div class="comments__header">
 		@if (this.ViewModel.SelectedItem is IHaveThingRowViewModel && this.ViewModel.Participant != null && this.ViewModel.Participant.IsAllowedTo(AccessRight.ReviewTask))
@@ -54,6 +55,6 @@
 	<ConfirmCancelPopup ViewModel="@this.ViewModel.ReplyConfirmCancelPopupViewModel"/>
 	@foreach (var comment in this.ViewModel.Comments.Items.OrderBy(x => x.CreatedOn))
 	{
-		<CommentCard ViewModel="@this.CreateCommentCardViewModel(comment)"/>
+		<CommentCard ViewModel="@this.CreateCommentCardViewModel(comment)" OnItemDoubleClick="@this.OnItemDoubleClick" />
 	}
 </AppAccordion>

--- a/UI_DSM.Client/Components/App/Comments/Comments.razor.cs
+++ b/UI_DSM.Client/Components/App/Comments/Comments.razor.cs
@@ -43,6 +43,12 @@ namespace UI_DSM.Client.Components.App.Comments
         public ICommentsViewModel ViewModel { get; set; }
 
         /// <summary>
+        ///     The <see cref="EventCallback{TValue}" /> to handle the double click on a property for navigation
+        /// </summary>
+        [Parameter]
+        public EventCallback<string> OnItemDoubleClick { get; set; }
+
+        /// <summary>
         ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()

--- a/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor
+++ b/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor
@@ -10,7 +10,7 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 <div class="app-key-values">
-	<AppAccordion Label="Parameters" Variant="AppAccordion.VariantValue.Tiny" PanelOpen="false">
+	<AppAccordion Label="Parameters" Id="parameterAccordion" Variant="AppAccordion.VariantValue.Tiny" @bind-PanelOpen="@this.IsPanelOpen">
 		<ul class="app-key-values__list">
 			@foreach (var item in this.Parameters)
 			{

--- a/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor.cs
+++ b/UI_DSM.Client/Components/App/ParametersComponent/ParametersComponent.razor.cs
@@ -33,5 +33,10 @@ namespace UI_DSM.Client.Components.App.ParametersComponent
         /// </summary>
         [Parameter]
         public Option CurrentOption { get; set; }
+
+        /// <summary>
+        ///     Value indicating if the panel is open
+        /// </summary>
+        public bool IsPanelOpen { get; set; }
     }
 }

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCard.razor.cs
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCard.razor.cs
@@ -48,7 +48,15 @@ namespace UI_DSM.Client.Components.App.SelectedItemCard
         [Parameter]
         public EventCallback<IHaveThingRowViewModel> MarkAsReviewed { get; set; }
 
-        /// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
+        /// <summary>
+        ///     The <see cref="EventCallback{TValue}" /> to handle the double click on a property for navigation
+        /// </summary>
+        [Parameter]
+        public EventCallback<string> OnItemDoubleClick { get; set; }
+
+        /// <summary>
+        ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
         public void Dispose()
         {
             this.disposables.ForEach(x => x.Dispose());
@@ -80,6 +88,7 @@ namespace UI_DSM.Client.Components.App.SelectedItemCard
         {
             this.parameters.Clear();
             this.parameters[nameof(this.ViewModel.SelectedItem)] = this.ViewModel.SelectedItem;
+            this.parameters[nameof(this.OnItemDoubleClick)] = this.OnItemDoubleClick;
             await this.InvokeAsync(this.StateHasChanged);
         }
     }

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/ElementBaseSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/ElementBaseSelectedItem.razor
@@ -10,8 +10,9 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 @inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.ElementBaseRowViewModel>
-<AppKeyValue Key="Name" Value="@(this.RowViewModel.Name)"/>
+
+<AppKeyValue Key="Name" Value="@(this.RowViewModel.Name)" OnItemDoubleClick="this.OnItemDoubleClick" />
 <AppKeyValue Key="ShortName" Value="@(this.RowViewModel.ShortName)"/>
 <AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)"/>
-<AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)"/>
+<AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)" OnItemDoubleClick="this.OnItemDoubleClick"/>
 <ParametersComponent Parameters="@(this.RowViewModel.Parameters)" CurrentOption="@(this.RowViewModel.CurrentOption)"/>

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/FunctionSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/FunctionSelectedItem.razor
@@ -10,10 +10,10 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 @inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.FunctionRowViewModel>
-<AppKeyValue Key="Name" Value="@(this.RowViewModel.Name)" />
+<AppKeyValue Key="Name" Value="@(this.RowViewModel.Name)" OnItemDoubleClick="this.OnItemDoubleClick" />
 <AppKeyValue Key="ShortName" Value="@(this.RowViewModel.ShortName)" />
 <AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)" />
-<AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)" />
-<ParametersComponent Parameters="@(this.RowViewModel.Parameters)" CurrentOption="@(this.RowViewModel.CurrentOption)"/>
-<AppKeyValues Key="Implemented by product(s)" Items="@(this.RowViewModel.ProductsImplement)" />
-<AppKeyValues Key="Satisfies requirement(s)" Items="@(this.RowViewModel.SatisfiedRequirements)" />
+<AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)" OnItemDoubleClick="this.OnItemDoubleClick" />
+<ParametersComponent Parameters="@(this.RowViewModel.Parameters)" CurrentOption="@(this.RowViewModel.CurrentOption)" />
+<AppKeyValues Key="Implemented by product(s)" Items="@(this.RowViewModel.ProductsImplement)" OnItemDoubleClick="this.OnItemDoubleClick"/>
+<AppKeyValues Key="Satisfies requirement(s)" Items="@(this.RowViewModel.SatisfiedRequirements)" OnItemDoubleClick="this.OnItemDoubleClick" />

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/InterfaceSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/InterfaceSelectedItem.razor
@@ -15,7 +15,7 @@
 @{
 	if (this.RowViewModel is InterfaceRowViewModel interfaceRow)
 	{
-		<AppKeyValue Key="Name" Value="@(this.RowViewModel.Id)" />
+		<AppKeyValue Key="Name" Value="@(interfaceRow.Id)" OnItemDoubleClick="this.OnItemDoubleClick" />
 		<AppKeyValue Key="Owner" Value="@(interfaceRow.Owner)" />
 		<AppKeyValue Key="Nature" Value="@(interfaceRow.Nature)" />
 	}

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/PortSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/PortSelectedItem.razor
@@ -12,5 +12,5 @@
 @inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.PortRowViewModel>
 <AppKeyValue Key="Name" Value="@(this.RowViewModel.Id)" />
 <AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)" />
-<AppKeyValue Key="Product Container" Value="@(this.RowViewModel.Container)" />
+<AppKeyValue Key="Product Container" Value="@(this.RowViewModel.Container)" OnItemDoubleClick="this.OnItemDoubleClick" />
 <AppKeyValue Key="Interface End" Value="@(this.RowViewModel.InterfaceEnd)" />

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/ProductSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/ProductSelectedItem.razor
@@ -10,10 +10,11 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 @inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.ProductRowViewModel>
-<AppKeyValue Key="Name" Value="@(this.RowViewModel.Name)"/>
+
+<AppKeyValue Key="Name" Value="@(this.RowViewModel.Name)" OnItemDoubleClick="this.OnItemDoubleClick" />
 <AppKeyValue Key="ShortName" Value="@(this.RowViewModel.ShortName)"/>
 <AppKeyValue Key="Owner" Value="@(this.RowViewModel.Owner)"/>
-<AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)" />
-<ParametersComponent Parameters="@(this.RowViewModel.Parameters)" CurrentOption="@(this.RowViewModel.CurrentOption)" />
-<AppKeyValues Key="Implement function(s)" Items="@(this.RowViewModel.ImplementedFunctions)" />
-<AppKeyValues Key="Satisfies requirement(s)" Items="@(this.RowViewModel.SatisfiedRequirements)" />
+<AppKeyValue Key="Container" Value="@(this.RowViewModel.Container)" OnItemDoubleClick="this.OnItemDoubleClick" />
+<ParametersComponent Parameters="@(this.RowViewModel.Parameters)" CurrentOption="@(this.RowViewModel.CurrentOption)"/>
+<AppKeyValues Key="Implement function(s)" Items="@(this.RowViewModel.ImplementedFunctions)" OnItemDoubleClick="this.OnItemDoubleClick" />
+<AppKeyValues Key="Satisfies requirement(s)" Items="@(this.RowViewModel.SatisfiedRequirements)" OnItemDoubleClick="this.OnItemDoubleClick"/>

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RelationshipSelectedItem.razor.cs
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RelationshipSelectedItem.razor.cs
@@ -53,6 +53,8 @@ namespace UI_DSM.Client.Components.App.SelectedItemCard.SelectedItemCardContent
 
             this.sourceParameters[nameof(this.SelectedItem)] = this.RowViewModel.SourceRow;
             this.targetParameters[nameof(this.SelectedItem)] = this.RowViewModel.TargetRow;
+            this.sourceParameters[nameof(this.OnItemDoubleClick)] = this.OnItemDoubleClick;
+            this.targetParameters[nameof(this.OnItemDoubleClick)] = this.OnItemDoubleClick;
             this.sourceCorrespondance = SelectedItemCardViewModel.GetCorrespondances(this.RowViewModel.SourceRow);
             this.targetCorrespondance = SelectedItemCardViewModel.GetCorrespondances(this.RowViewModel.TargetRow);
         }

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RequirementSelectedItem.razor
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/RequirementSelectedItem.razor
@@ -10,7 +10,7 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 @inherits SelectedItemBase<UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel.RequirementRowViewModel>
-<AppKeyValue Key="ID" Value="@(this.RowViewModel.Id)"/>
+<AppKeyValue Key="ID" Value="@(this.RowViewModel.Id)" OnItemDoubleClick="this.OnItemDoubleClick"/>
 <AppKeyValue Key="Name" Value="@(this.RowViewModel.Name)"/>
 <AppKeyValue Key="Description"
              Value="@(this.RowViewModel.Definition)"
@@ -20,11 +20,11 @@
 <AppKeyValue Key="Verification method" Value="@(this.RowViewModel.VerificationMethod)"/>
 <AppKeyValue Key="Verification stage" Value="@(this.RowViewModel.VerificationStage)"/>
 <AppKeyValue Key="Justification" Value="@(this.RowViewModel.Justification)"/>
-<AppKeyValues Key="Derivation from" Items="@(this.RowViewModel.DerivesFrom)"/>
-<AppKeyValues Key="Derivation to" Items="@(this.RowViewModel.DerivesTo)"/>
-<AppKeyValues Key="Traces" Items="@(this.RowViewModel.Traces)"/>
-<AppKeyValues Key="Traced by" Items="@(this.RowViewModel.TracedBy)"/>
-<AppKeyValues Key="Satisfied by function(s)" Items="@(this.RowViewModel.SatisfyByFunction)"/>
-<AppKeyValues Key="Satisfied by product(s)" Items="@(this.RowViewModel.SatisfyByProduct)"/>
-<AppKeyValues Key="Parametric Constraints" Items="@(this.RowViewModel.ParametricConstraints)"/>
+<AppKeyValues Key="Derivation from" Items="@(this.RowViewModel.DerivesFrom)" OnItemDoubleClick="this.OnItemDoubleClick"/>
+<AppKeyValues Key="Derivation to" Items="@(this.RowViewModel.DerivesTo)" OnItemDoubleClick="this.OnItemDoubleClick" />
+<AppKeyValues Key="Traces" Items="@(this.RowViewModel.Traces)" OnItemDoubleClick="this.OnItemDoubleClick"/>
+<AppKeyValues Key="Traced by" Items="@(this.RowViewModel.TracedBy)" OnItemDoubleClick="this.OnItemDoubleClick" />
+<AppKeyValues Key="Satisfied by function(s)" Items="@(this.RowViewModel.SatisfyByFunction)" OnItemDoubleClick="this.OnItemDoubleClick"/>
+<AppKeyValues Key="Satisfied by product(s)" Items="@(this.RowViewModel.SatisfyByProduct)" OnItemDoubleClick="this.OnItemDoubleClick"/>
+<AppKeyValues Key="Parametric Constraints" Items="@(this.RowViewModel.ParametricConstraints)" />
 <AppKeyValues Key="Associated Categories" Items="@(this.RowViewModel.Categories)"/>

--- a/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/SelectedItemBase.razor.cs
+++ b/UI_DSM.Client/Components/App/SelectedItemCard/SelectedItemCardContent/SelectedItemBase.razor.cs
@@ -15,6 +15,8 @@ namespace UI_DSM.Client.Components.App.SelectedItemCard.SelectedItemCardContent
 {
     using Microsoft.AspNetCore.Components;
 
+    using UI_DSM.Client.ViewModels.App.SelectedItemCard;
+
     /// <summary>
     ///     Base component that provide information for related to a selected item
     /// </summary>
@@ -31,6 +33,18 @@ namespace UI_DSM.Client.Components.App.SelectedItemCard.SelectedItemCardContent
         /// </summary>
         [Parameter]
         public object SelectedItem { get; set; }
+
+        /// <summary>
+        ///     The <see cref="ISelectedItemCardViewModel" />
+        /// </summary>
+        [Parameter]
+        public ISelectedItemCardViewModel ViewModel { get; set; }
+
+        /// <summary>
+        ///     The <see cref="EventCallback{TValue}" /> to handle the double click on a property for navigation
+        /// </summary>
+        [Parameter]
+        public EventCallback<string> OnItemDoubleClick { get; set; }
 
         /// <summary>
         ///     Method invoked when the component has received parameters from its parent in

--- a/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityCell.razor
+++ b/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityCell.razor
@@ -9,7 +9,7 @@
 // 
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
-<div @onclick="() => this.OnClick.InvokeAsync(this.RelationshipRow)" >
+<div id="cell_@this.RelationshipRow.ThingId" @onclick="() => this.OnClick.InvokeAsync(this.RelationshipRow)" >
 	<HaveThingRowIcons Row="this.RelationshipRow"/>
 	<FeatherCheck Size="24" Color="currentColor" StrokeWidth="2"/>
 </div>

--- a/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityTable.razor
+++ b/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityTable.razor
@@ -19,7 +19,7 @@
 					<th>@this.ViewModel.HeaderName</th>
 					@foreach (var column in this.ViewModel.VisibleColumns)
 					{
-						<th @onclick="() => this.ViewModel.SelectElement(column)">
+						<th @onclick="() => this.ViewModel.SelectElement(column)" id="column_@column.ThingId">
 							<span class="@this.GetHeaderClass(column)">
 								<HaveThingRowIcons Row="column"/>
 								@column.Id
@@ -32,7 +32,7 @@
 				@foreach (var currentRow in this.ViewModel.VisibleRows)
 				{
 					<tr class="@this.GetTrClass(currentRow)">
-						<th @onclick="() => this.ViewModel.SelectElement(currentRow)">
+						<th @onclick="() => this.ViewModel.SelectElement(currentRow)" id="row_@currentRow.ThingId">
 							<span class="@this.GetHeaderClass(currentRow)">
 								<HaveThingRowIcons Row="currentRow"/>
 								@currentRow.Id

--- a/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityTable.razor.cs
+++ b/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityTable.razor.cs
@@ -14,6 +14,7 @@
 namespace UI_DSM.Client.Components.App.TraceabilityTable
 {
     using Microsoft.AspNetCore.Components;
+    using Microsoft.JSInterop;
 
     using ReactiveUI;
 
@@ -32,17 +33,17 @@ namespace UI_DSM.Client.Components.App.TraceabilityTable
         private readonly List<IDisposable> disposables = new();
 
         /// <summary>
+        ///     Backing field for the <see cref="IsLoading" /> property
+        /// </summary>
+        private bool isLoading;
+
+        /// <summary>
         ///     The <see cref="ITraceabilityTableViewModel" />
         /// </summary>
         private ITraceabilityTableViewModel ViewModel { get; set; }
 
         /// <summary>
-        /// Backing field for the <see cref="IsLoading"/> property
-        /// </summary>
-        private bool isLoading;
-
-        /// <summary>
-        /// Gets or sets if the view is loading
+        ///     Gets or sets if the view is loading
         /// </summary>
         [Parameter]
         public bool IsLoading
@@ -56,13 +57,17 @@ namespace UI_DSM.Client.Components.App.TraceabilityTable
         }
 
         /// <summary>
-        ///     Method invoked when the component is ready to start, having received its
-        ///     initial parameters from its parent in the render tree.
+        ///     The <see cref="IJSRuntime" />
         /// </summary>
-        protected override void OnInitialized()
+        [Inject]
+        public IJSRuntime JsRuntime { get; set; }
+
+        /// <summary>
+        ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
         {
-            this.IsLoading = true;
-            base.OnInitialized();
+            this.disposables.ForEach(x => x.Dispose());
         }
 
         /// <summary>
@@ -75,7 +80,7 @@ namespace UI_DSM.Client.Components.App.TraceabilityTable
             this.IsLoading = false;
 
             await this.InvokeAsync(this.StateHasChanged);
-            
+
             this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.VisibilityState.CurrentState)
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
         }
@@ -88,6 +93,82 @@ namespace UI_DSM.Client.Components.App.TraceabilityTable
         {
             this.ViewModel.UpdateTable();
             await this.InvokeAsync(this.StateHasChanged);
+        }
+
+        /// <summary>
+        ///     Scrolls the table to the selected item
+        /// </summary>
+        /// <param name="itemName">The name of the item</param>
+        /// <returns>A <see cref="Task" /></returns>
+        public async Task ScrollToElement(string itemName)
+        {
+            if (itemName.Contains(" -> "))
+            {
+                var splittedName = itemName.Split(" -> ");
+                
+                var sourceItem = this.ViewModel.VisibleRows
+                    .FirstOrDefault(x => string.Equals(splittedName[0], x.Id, StringComparison.InvariantCultureIgnoreCase));
+
+                var targetItem= this.ViewModel.VisibleColumns
+                    .FirstOrDefault(x => string.Equals(splittedName[1], x.Id, StringComparison.InvariantCultureIgnoreCase));
+
+                var relationShip = this.ViewModel.GetRelationship(sourceItem, targetItem);
+
+                if (relationShip != null)
+                {
+                    await this.JsRuntime.InvokeVoidAsync("scrollToElement", $"cell_{relationShip.ThingId}", "center", "center");
+                }
+
+                return;
+            }
+
+            var item = this.ViewModel.VisibleRows
+                .FirstOrDefault(x => string.Equals(itemName, x.Id, StringComparison.InvariantCultureIgnoreCase));
+
+            if (item != null)
+            {
+                var relationShip = this.ViewModel.GetRelationship(item, this.ViewModel.SelectedElement)
+                    ?? this.ViewModel.GetRelationship(this.ViewModel.SelectedElement, item);
+
+                if (relationShip != null)
+                {
+                    await this.JsRuntime.InvokeVoidAsync("scrollToElement", $"cell_{relationShip.ThingId}", "center", "center");
+                }
+                else
+                {
+                    await this.JsRuntime.InvokeVoidAsync("scrollToElement", $"row_{item.ThingId}", "center", "nearest");
+                }
+            }
+            else
+            {
+                item = this.ViewModel.VisibleColumns
+                    .FirstOrDefault(x => string.Equals(itemName, x.Id, StringComparison.InvariantCultureIgnoreCase));
+
+                if (item != null)
+                {
+                    var relationShip = this.ViewModel.GetRelationship(item, this.ViewModel.SelectedElement)
+                                       ?? this.ViewModel.GetRelationship(this.ViewModel.SelectedElement, item);
+
+                    if (relationShip != null)
+                    {
+                        await this.JsRuntime.InvokeVoidAsync("scrollToElement", $"cell_{relationShip.ThingId}", "center", "center");
+                    }
+                    else
+                    {
+                        await this.JsRuntime.InvokeVoidAsync("scrollToElement", $"column_{item.ThingId}", "nearest", "center");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Method invoked when the component is ready to start, having received its
+        ///     initial parameters from its parent in the render tree.
+        /// </summary>
+        protected override void OnInitialized()
+        {
+            this.IsLoading = true;
+            base.OnInitialized();
         }
 
         /// <summary>
@@ -132,14 +213,6 @@ namespace UI_DSM.Client.Components.App.TraceabilityTable
         {
             var cssClass = row.Id.Length < 30 ? string.Empty : "app-traceability-table__header--large";
             return cssClass;
-        }
-
-        /// <summary>
-        ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        public void Dispose()
-        {
-            this.disposables.ForEach(x => x.Dispose());
         }
     }
 }

--- a/UI_DSM.Client/Components/NormalUser/ProjectReview/ReviewCreation.razor
+++ b/UI_DSM.Client/Components/NormalUser/ProjectReview/ReviewCreation.razor
@@ -11,6 +11,7 @@
 -------------------------------------------------------------------------------------------------------->
 @using UI_DSM.Client.Enumerator
 
+<CascadingValue Name="PreventValidation" Value="true">
 <EditForm Context="editFormContext" Model="@this.ViewModel.Review" OnValidSubmit="@this.ViewModel.OnValidSubmit">
 	<DataAnnotationsValidator />
 	<DxFormLayout>
@@ -22,10 +23,10 @@
 		</DxFormLayoutItem>
 		<DxFormLayoutItem Caption="Engineering Models :" ColSpanMd="12">
 			<DxListBox Data="@this.ProjectModels"
-					   @bind-Values="@this.ViewModel.SelectedModels"
-					   ShowCheckboxes="true"
-					   SelectionMode="ListBoxSelectionMode.Multiple" 
-					   TextFieldName="@nameof(Model.ModelName)"/>
+			           @bind-Values="@this.ViewModel.SelectedModels"
+			           ShowCheckboxes="true"
+			           SelectionMode="ListBoxSelectionMode.Multiple" 
+			           TextFieldName="@nameof(Model.ModelName)"/>
 		</DxFormLayoutItem>
 	</DxFormLayout>
 	<ValidationSummary/>
@@ -34,3 +35,4 @@
 		<DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Create" SubmitFormOnClick="true" Enabled="this.ViewModel.CreationStatus != CreationStatus.Creating"/>
 	</div>
 </EditForm>
+</CascadingValue>

--- a/UI_DSM.Client/Components/NormalUser/ProjectReview/ReviewObjectiveCreation.razor
+++ b/UI_DSM.Client/Components/NormalUser/ProjectReview/ReviewObjectiveCreation.razor
@@ -10,21 +10,22 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 @using UI_DSM.Client.Enumerator
-
+<CascadingValue Name="PreventValidation" Value="true">
 <EditForm Context="editFormContext" Model="@this.ViewModel.ReviewObjective" OnValidSubmit="@this.ViewModel.OnValidSubmit">
 	<div>PRR</div>
 	<DxListBox Data="@this.AvailableReviewObjectiveCreationDtoPrr"
-				   @bind-Values="@this.ViewModel.SelectedReviewObjectivesPrr"
-					   ShowCheckboxes="true"
-					   SelectionMode="ListBoxSelectionMode.Multiple"/>
+	           @bind-Values="@this.ViewModel.SelectedReviewObjectivesPrr"
+	           ShowCheckboxes="true"
+	           SelectionMode="ListBoxSelectionMode.Multiple"/>
 	<div>SRR</div>
 	<DxListBox Data="@this.AvailableReviewObjectiveCreationDtoSrr"
-			   @bind-Values="@this.ViewModel.SelectedReviewObjectivesSrr"
-			   ShowCheckboxes="true"
-			   SelectionMode="ListBoxSelectionMode.Multiple" />
+	           @bind-Values="@this.ViewModel.SelectedReviewObjectivesSrr"
+	           ShowCheckboxes="true"
+	           SelectionMode="ListBoxSelectionMode.Multiple" />
 	<div class="modal-footer m-top-10px">
 		<DxButton RenderStyle="ButtonRenderStyle.Primary" Text="@this.CreationText"
-				  Enabled="@(this.ViewModel.ReviewObjectivesCreationStatus != CreationStatus.Creating)"
+		          Enabled="@(this.ViewModel.ReviewObjectivesCreationStatus != CreationStatus.Creating)"
 		          SubmitFormOnClick="true" />
 	</div>
 </EditForm>
+</CascadingValue>

--- a/UI_DSM.Client/Components/NormalUser/Views/BaseView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/BaseView.razor.cs
@@ -86,5 +86,12 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         /// <param name="annotatableItems">A collection of <see cref="AnnotatableItem"/></param>
         /// <returns>A <see cref="Task"/></returns>
         public abstract Task UpdateAnnotatableRows(List<AnnotatableItem> annotatableItems);
+
+        /// <summary>
+        ///     Tries to navigate to a corresponding item
+        /// </summary>
+        /// <param name="itemName">The name of the item to navigate to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        public abstract Task TryNavigateToItem(string itemName);
     }
 }

--- a/UI_DSM.Client/Components/NormalUser/Views/DocumentBased.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/DocumentBased.razor.cs
@@ -32,5 +32,15 @@ namespace UI_DSM.Client.Components.NormalUser.Views
             this.ViewModel.SelectedElement = row;
             return this.HasChanged();
         }
+
+        /// <summary>
+        ///     Tries to navigate to a corresponding item
+        /// </summary>
+        /// <param name="itemName">The name of the item to navigate to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        public override Task TryNavigateToItem(string itemName)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/UI_DSM.Client/Components/NormalUser/Views/ElementBreakdownStructureView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/ElementBreakdownStructureView.razor.cs
@@ -64,6 +64,16 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         }
 
         /// <summary>
+        ///     Tries to navigate to a corresponding item
+        /// </summary>
+        /// <param name="itemName">The name of the item to navigate to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        public override Task TryNavigateToItem(string itemName)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         ///     Initialize the correspondant ViewModel for this component
         /// </summary>
         /// <param name="things">The collection of <see cref="Thing" /></param>

--- a/UI_DSM.Client/Components/NormalUser/Views/HaveTraceabilityTableView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/HaveTraceabilityTableView.razor.cs
@@ -90,6 +90,16 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         }
 
         /// <summary>
+        ///     Tries to navigate to a corresponding item
+        /// </summary>
+        /// <param name="itemName">The name of the item to navigate to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        public override Task TryNavigateToItem(string itemName)
+        {
+            return this.Table.ScrollToElement(itemName);
+        }
+
+        /// <summary>
         ///     Apply the filtering on rows
         /// </summary>
         /// <returns>A <see cref="Task" /></returns>

--- a/UI_DSM.Client/Components/NormalUser/Views/InterfaceView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/InterfaceView.razor.cs
@@ -106,6 +106,16 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         }
 
         /// <summary>
+        ///     Tries to navigate to a corresponding item
+        /// </summary>
+        /// <param name="itemName">The name of the item to navigate to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        public override Task TryNavigateToItem(string itemName)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         ///     Method invoked when the component is ready to start, having received its
         ///     initial parameters from its parent in the render tree.
         /// </summary>

--- a/UI_DSM.Client/Components/NormalUser/Views/PhysicalFlowView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/PhysicalFlowView.razor.cs
@@ -72,6 +72,16 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         }
 
         /// <summary>
+        ///     Tries to navigate to a corresponding item
+        /// </summary>
+        /// <param name="itemName">The name of the item to navigate to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        public override Task TryNavigateToItem(string itemName)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         ///     Initialize the correspondant ViewModel for this component
         /// </summary>
         /// <param name="things">The collection of <see cref="Thing" /></param>

--- a/UI_DSM.Client/Components/NormalUser/Views/RequirementBreakdownStructureView.razor
+++ b/UI_DSM.Client/Components/NormalUser/Views/RequirementBreakdownStructureView.razor
@@ -38,7 +38,8 @@
 			AllowSelectRowByClick="true"
 			ShowFilterRow="true"
 			HorizontalScrollBarMode="ScrollBarMode.Visible"
-			ShowGroupPanel="true">
+			ShowGroupPanel="true"
+			FocusedRowEnabled="true">
 			<Columns>
 
 				<DxGridDataColumn  ShowInColumnChooser="false">

--- a/UI_DSM.Client/Components/NormalUser/Views/RequirementBreakdownStructureView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/RequirementBreakdownStructureView.razor.cs
@@ -41,16 +41,6 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         protected DxGrid DxGrid { get; set; }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
-        /// </summary>
-        protected override void OnInitialized()
-        {
-            this.IsLoading = true;
-            base.OnInitialized();
-        }
-
-        /// <summary>
         ///     Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()
@@ -76,6 +66,18 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         }
 
         /// <summary>
+        ///     Tries to navigate to a corresponding item
+        /// </summary>
+        /// <param name="itemName">The name of the item to navigate to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        public override Task TryNavigateToItem(string itemName)
+        {
+            var item = this.ViewModel.Rows.FirstOrDefault(x => string.Equals(itemName, x.Id, StringComparison.InvariantCultureIgnoreCase));
+
+            return item != null ? this.DxGrid.SetFocusedDataItemAsync(item) : Task.CompletedTask;
+        }
+
+        /// <summary>
         ///     Initialize the correspondant ViewModel for this component
         /// </summary>
         /// <param name="things">The collection of <see cref="Thing" /></param>
@@ -92,6 +94,16 @@ namespace UI_DSM.Client.Components.NormalUser.Views
             this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.FilterViewModel.IsFilterVisible)
                 .Where(x => !x)
                 .Subscribe(_ => this.InvokeAsync(this.OnRowFilteringClose)));
+        }
+
+        /// <summary>
+        ///     Method invoked when the component is ready to start, having received its
+        ///     initial parameters from its parent in the render tree.
+        /// </summary>
+        protected override void OnInitialized()
+        {
+            this.IsLoading = true;
+            base.OnInitialized();
         }
 
         /// <summary>

--- a/UI_DSM.Client/Components/NormalUser/Views/RequirementVerificationControlView.razor
+++ b/UI_DSM.Client/Components/NormalUser/Views/RequirementVerificationControlView.razor
@@ -36,7 +36,8 @@
 	        SelectionMode="GridSelectionMode.Single"
 	        AllowSelectRowByClick="true"
 	        ShowFilterRow="true"
-	        HorizontalScrollBarMode="ScrollBarMode.Visible">
+	        HorizontalScrollBarMode="ScrollBarMode.Visible"
+	        FocusedRowEnabled="true">
 		<Columns>
 
 			<DxGridDataColumn ShowInColumnChooser="false">

--- a/UI_DSM.Client/Pages/Administration/RolePages/RolePage.razor
+++ b/UI_DSM.Client/Pages/Administration/RolePages/RolePage.razor
@@ -14,10 +14,10 @@
 @attribute [Authorize(Roles = "Administrator")]
 
 <UI_DSM.Client.Components.App.LoadingComponent.LoadingComponent IsLoading="this.ViewModel.RoleDetailsViewModel.Role is null">
-
+	<CascadingValue Name="PreventValidation" Value="true">
 	<DxFormLayout>
 		<DxFormLayoutItem Caption="Enable Modification">
-			<DxCheckBox @bind-Checked="this.ViewModel.ModificationEnabled"/>
+			<DxCheckBox @bind-Checked="this.ViewModel.ModificationEnabled" />
 		</DxFormLayoutItem>
 	</DxFormLayout>
 	<EditForm Context="editFormContext" Model="@this.ViewModel.RoleDetailsViewModel.Role" OnValidSubmit="@this.ViewModel.UpdateRole">
@@ -31,4 +31,5 @@
 			<DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Update" SubmitFormOnClick="true" Enabled="@this.ViewModel.ModificationEnabled"/>
 		</div>
 	</EditForm>
+	</CascadingValue>
 </UI_DSM.Client.Components.App.LoadingComponent.LoadingComponent>

--- a/UI_DSM.Client/Pages/NormalUser/ReviewTaskPage/ReviewTaskPage.razor
+++ b/UI_DSM.Client/Pages/NormalUser/ReviewTaskPage/ReviewTaskPage.razor
@@ -121,10 +121,10 @@
 
 			<aside class="task-page__sidebar task-page__sidebar__right">
 				<ConfirmCancelPopup ViewModel="this.ViewModel.ConfirmCancelDialog"/>
-				<SelectedItemCard @ref="this.SelectedItemCard" MarkAsReviewed="this.ViewModel.OpenConfirmDialog"/>
+				<SelectedItemCard @ref="this.SelectedItemCard" OnItemDoubleClick="this.TryNavigateToItem" MarkAsReviewed="this.ViewModel.OpenConfirmDialog"/>
 				<RelatedViews MainRelatedView="@(this.ViewModel.GetMainRelatedView())" OtherRelatedViews="@(this.ViewModel.GetOtherRelatedViews())"
 				              OnViewSelect="@(this.OnViewSelect)"/>
-				<Comments @ref="this.Comments"/>
+				<Comments @ref="this.Comments" OnItemDoubleClick="this.TryNavigateToItem" />
 			</aside>
 		</UI_DSM.Client.Components.App.LoadingComponent.LoadingComponent>
 	}

--- a/UI_DSM.Client/Pages/NormalUser/ReviewTaskPage/ReviewTaskPage.razor.cs
+++ b/UI_DSM.Client/Pages/NormalUser/ReviewTaskPage/ReviewTaskPage.razor.cs
@@ -139,25 +139,10 @@ namespace UI_DSM.Client.Pages.NormalUser.ReviewTaskPage
                 .Where(x => !x).Subscribe(async _ => await this.OnConfirmClosed()));
 
             this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.DoneConfirmCancelPopup.IsVisible)
-               .Where(x => !x).Subscribe(async _ => await this.OnConfirmClosed()));
+                .Where(x => !x).Subscribe(async _ => await this.OnConfirmClosed()));
 
             this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsLinkerVisible)
                 .Subscribe(async x => await this.OnLinkerVisibilityChanged(x)));
-        }
-
-        /// <summary>
-        /// Handle the change of visible of the <see cref="AnnotationLinker"/> component
-        /// </summary>
-        /// <param name="value">The new visibility</param>
-        /// <returns>A <see cref="Task"/></returns>
-        private async Task OnLinkerVisibilityChanged(bool value)
-        {
-            if (!value && this.ViewModel.CurrentBaseViewInstance != null)
-            {
-                await this.ViewModel.CurrentBaseViewInstance.HasChanged();
-            }
-
-            await this.InvokeAsync(this.StateHasChanged);
         }
 
         /// <summary>
@@ -224,6 +209,21 @@ namespace UI_DSM.Client.Pages.NormalUser.ReviewTaskPage
         }
 
         /// <summary>
+        ///     Handle the change of visible of the <see cref="AnnotationLinker" /> component
+        /// </summary>
+        /// <param name="value">The new visibility</param>
+        /// <returns>A <see cref="Task" /></returns>
+        private async Task OnLinkerVisibilityChanged(bool value)
+        {
+            if (!value && this.ViewModel.CurrentBaseViewInstance != null)
+            {
+                await this.ViewModel.CurrentBaseViewInstance.HasChanged();
+            }
+
+            await this.InvokeAsync(this.StateHasChanged);
+        }
+
+        /// <summary>
         ///     Handle the count Changed event on the Comments collection
         /// </summary>
         /// <param name="baseView">The <see cref="BaseView" /></param>
@@ -283,7 +283,7 @@ namespace UI_DSM.Client.Pages.NormalUser.ReviewTaskPage
                 if (this.ViewModel.CurrentBaseViewInstance != null)
                 {
                     await this.ViewModel.CurrentBaseViewInstance.InitializeViewModel(this.ViewModel.Things, projectId, reviewId, this.ViewModel.GetPrefilters(),
-                        this.ViewModel.ReviewObjective.AdditionnalColumnsVisibleAtStart); 
+                        this.ViewModel.ReviewObjective.AdditionnalColumnsVisibleAtStart);
 
                     this.ViewModel.CurrentBaseViewInstance.TrySetSelectedItem(this.SelectedItem);
                 }
@@ -388,6 +388,16 @@ namespace UI_DSM.Client.Pages.NormalUser.ReviewTaskPage
         private string GetModelName()
         {
             return this.ViewModel.CurrentModel == null ? "No model available" : this.ViewModel.CurrentModel.ModelName;
+        }
+
+        /// <summary>
+        ///     Tries to navigate to a corresponding item
+        /// </summary>
+        /// <param name="itemName">The name of the item to navigate to</param>
+        /// <returns>A <see cref="Task" /></returns>
+        private Task TryNavigateToItem(string itemName)
+        {
+            return this.ViewModel.CurrentBaseViewInstance != null ? this.ViewModel.CurrentBaseViewInstance.TryNavigateToItem(itemName) : Task.CompletedTask;
         }
     }
 }

--- a/UI_DSM.Client/Program.cs
+++ b/UI_DSM.Client/Program.cs
@@ -20,6 +20,8 @@ namespace UI_DSM.Client
 
     using CDP4JsonSerializer;
 
+    using DevExpress.Blazor;
+
     using Microsoft.AspNetCore.Components.Authorization;
     using Microsoft.AspNetCore.Components.Web;
     using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -114,7 +116,7 @@ namespace UI_DSM.Client
             builder.Services.AddAuthorizationCore();
 
             builder.Services.AddBlazoredSessionStorage();
-            builder.Services.AddDevExpressBlazor();
+            builder.Services.AddDevExpressBlazor(configure => configure.SizeMode = SizeMode.Medium);
         }
     }
 }

--- a/UI_DSM.Client/UI_DSM.Client.csproj
+++ b/UI_DSM.Client/UI_DSM.Client.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Blazored.SessionStorage" Version="2.2.0" />
     <PackageReference Include="CDP4JsonSerializer-CE" Version="8.3.0" />
     <PackageReference Include="CDP4ServicesDal-CE" Version="8.3.0" />
-    <PackageReference Include="DevExpress.Blazor" Version="22.1.4" />
+    <PackageReference Include="DevExpress.Blazor" Version="22.2.3" />
     <PackageReference Include="Feather.Blazor" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.7" />

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/HaveTraceabilityTableViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/HaveTraceabilityTableViewModel.cs
@@ -380,6 +380,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <returns>The <see cref="RelationshipRowViewModel" /> if exists</returns>
         private RelationshipRowViewModel GetRelationship(IHaveThingRowViewModel row, IHaveThingRowViewModel column)
         {
+            if (row == null || column == null)
+            {
+                return null;
+            }
+
             if (this.AvailableRelationships.TryGetValue(row.ThingId, out var possibleRelationships))
             {
                 return possibleRelationships.TryGetValue(column.ThingId, out var relationshipRow) ? relationshipRow : null;

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/FunctionRowViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/FunctionRowViewModel.cs
@@ -57,8 +57,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         /// <summary>
         ///     The names of <see cref="Requirement"/> that are satisfied by the function
         /// </summary>
-        public IEnumerable<string> SatisfiedRequirements => this.Thing.GetRelatedThingsName(ThingExtension.SatisfyCategoryName, ClassKind.Requirement, 
-            true, false);
+        public IEnumerable<string> SatisfiedRequirements => this.Thing.GetRelatedThingsName(ThingExtension.SatisfyCategoryName, ClassKind.Requirement);
 
         /// <summary>
         ///     The names of products that implements the function

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/ProductRowViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RowViewModel/ProductRowViewModel.cs
@@ -119,8 +119,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel
         /// <summary>
         ///     The names of <see cref="Requirement"/> that are satisfied by the product
         /// </summary>
-        public IEnumerable<string> SatisfiedRequirements => this.Thing.GetRelatedThingsName(ThingExtension.SatisfyCategoryName, ClassKind.Requirement, 
-             true, false);
+        public IEnumerable<string> SatisfiedRequirements => this.Thing.GetRelatedThingsName(ThingExtension.SatisfyCategoryName, ClassKind.Requirement);
 
         /// <summary>
         ///     The names of functions that are implemented by the product

--- a/UI_DSM.Client/_Imports.razor
+++ b/UI_DSM.Client/_Imports.razor
@@ -38,6 +38,9 @@
 @using UI_DSM.Client.Components.App.ParameterValuesVisualizer
 @using UI_DSM.Client.Components.App.ParametersComponent
 @using UI_DSM.Client.Components.App.ValuesVisualizer
+@using UI_DSM.Client.Components.App.AppKeyValue
+@using UI_DSM.Client.Components.App.AppKeyValues
+@using UI_DSM.Client.Components.App.AppAccordion
 @using UI_DSM.Client.Shared.TopMenu
 @using DevExpress.Blazor
 @using Microsoft.AspNetCore.Authorization

--- a/UI_DSM.Client/wwwroot/index.html
+++ b/UI_DSM.Client/wwwroot/index.html
@@ -30,6 +30,7 @@
 	<script src="_content/Z.Blazor.Diagrams/script.min.js"></script>
 	<script src="_content/Radzen.Blazor/Radzen.Blazor.js"></script>
 	<script src="_framework/blazor.webassembly.js"></script>
+	<script src="js/ScrollToElement.js"></script>
 </body>
 </html>
 

--- a/UI_DSM.Client/wwwroot/js/ScrollToElement.js
+++ b/UI_DSM.Client/wwwroot/js/ScrollToElement.js
@@ -1,0 +1,7 @@
+﻿window.scrollToElement = (elementId, blockOption, inlineOption) => {
+    const element = document.getElementById(elementId);
+
+    if (element) {
+        element.scrollIntoView({ block: blockOption, inline: inlineOption });
+    }
+}

--- a/UI_DSM.Serializer.Json.Tests/UI_DSM.Serializer.Json.Tests.csproj
+++ b/UI_DSM.Serializer.Json.Tests/UI_DSM.Serializer.Json.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="System.Security.Permissions" Version="5.0.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UI_DSM.Serializer.Json/UI_DSM.Serializer.Json.csproj
+++ b/UI_DSM.Serializer.Json/UI_DSM.Serializer.Json.csproj
@@ -4,14 +4,11 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <AssemblyVersion>1.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\UI_DSM.Shared\UI_DSM.Shared.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="AutoGenDtoSerializer\" />
   </ItemGroup>
 
 </Project>

--- a/UI_DSM.Server/UI_DSM.Server.csproj
+++ b/UI_DSM.Server/UI_DSM.Server.csproj
@@ -14,14 +14,15 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NLog" Version="4.7.10" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.7" />
-  </ItemGroup>
+    <PackageReference Include="System.Security.Permissions" Version="5.0.0" />
+</ItemGroup>
 
-  <ItemGroup>
+<ItemGroup>
     <ProjectReference Include="..\UI_DSM.Client\UI_DSM.Client.csproj" />
     <ProjectReference Include="..\UI_DSM.Serializer.Json\UI_DSM.Serializer.Json.csproj" />
     <ProjectReference Include="..\UI_DSM.Shared\UI_DSM.Shared.csproj" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/UI-DSM/pulls) open
- [x] I have verified that I am following the UI-DSM [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/UI-DSM/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #161 

By double-clicking on property name inside the context panel or inside the linked items to a comment, the view recenter/focus on the selected element.
Implemented for all traceabilities view and for RequirementBreakdown/RequirementVerification. Did not find a way to implement it for the RadzenGrid for now (InterfaceView/ProductBreakdown/FunctionBreakdown)
<!-- Thanks for contributing to UI-DSM! -->