### PR TITLE
Columns can be filtered with/without traces : Fix #204

### DIFF
--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewTestFixture.cs
@@ -28,6 +28,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using NUnit.Framework;
 
     using UI_DSM.Client.Components.NormalUser.Views;
+    using UI_DSM.Client.Enumerator;
     using UI_DSM.Client.Services.ReviewItemService;
     using UI_DSM.Client.Tests.Helpers;
     using UI_DSM.Client.ViewModels.App.ConnectionVisibilitySelector;
@@ -225,6 +226,15 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                 this.viewModel.TraceabilityTableViewModel.SelectedElement = this.viewModel.TraceabilityTableViewModel.Columns.Last();
 
                 await renderer.Instance.TryNavigateToItem(elementUsage.Name);
+                runtime.VerifyInvoke("scrollToElement", 6);
+
+                this.viewModel.TraceabilityTableViewModel.ColumnVisibilityState.CurrentState = ConnectionToVisibilityState.Connected;
+
+                await renderer.Instance.TryNavigateToItem("1");
+                runtime.VerifyInvoke("scrollToElement", 6);
+                this.viewModel.TraceabilityTableViewModel.ColumnVisibilityState.CurrentState = ConnectionToVisibilityState.NotConnected;
+
+                await renderer.Instance.TryNavigateToItem($"{elementUsage.Name} -> 2");
                 runtime.VerifyInvoke("scrollToElement", 6);
             }
             catch

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToProductViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToProductViewTestFixture.cs
@@ -298,13 +298,8 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     Assert.That(renderer.FindComponents<FeatherMessageCircle>(), Has.Count.EqualTo(1));
                 });
 
-                this.viewModel.TraceabilityTableViewModel.VisibilityState.CurrentState = ConnectionToVisibilityState.Connected;
-                var invisibleRow = renderer.FindAll(".invisible-row");
-                Assert.That(invisibleRow, Has.Count.EqualTo(0));
-
-                this.viewModel.TraceabilityTableViewModel.VisibilityState.CurrentState = ConnectionToVisibilityState.NotConnected;
-                invisibleRow.Refresh();
-                Assert.That(invisibleRow, Has.Count.EqualTo(1));
+                this.viewModel.TraceabilityTableViewModel.RowVisibilityState.CurrentState = ConnectionToVisibilityState.Connected;
+                this.viewModel.TraceabilityTableViewModel.RowVisibilityState.CurrentState = ConnectionToVisibilityState.NotConnected;
 
                 var filters = renderer.FindComponents<Filter>();
                 var columnFiltering = filters.First(x => x.Instance.Id.Contains("column"));
@@ -320,8 +315,10 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                 Assert.Multiple(() =>
                 {
                     Assert.That(renderer.FindComponents<FeatherCheck>(), Has.Count.EqualTo(0));
-                    Assert.That(renderer.FindComponents<FeatherMessageCircle>(), Has.Count.EqualTo(0));
+                    Assert.That(renderer.FindComponents<FeatherMessageCircle>(), Has.Count.EqualTo(1));
                 });
+
+                this.viewModel.TraceabilityTableViewModel.RowVisibilityState.CurrentState = ConnectionToVisibilityState.All;
 
                 var invalidRows = renderer.FindAll(".invalid");
                 Assert.That(invalidRows, Has.Count.EqualTo(0));

--- a/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityTable.razor
+++ b/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityTable.razor
@@ -17,7 +17,7 @@
 				<thead>
 				<tr>
 					<th>@this.ViewModel.HeaderName</th>
-					@foreach (var column in this.ViewModel.VisibleColumns)
+					@foreach (var column in this.columnsToDisplay)
 					{
 						<th @onclick="() => this.ViewModel.SelectElement(column)" id="column_@column.ThingId">
 							<span class="@this.GetHeaderClass(column)">
@@ -29,7 +29,7 @@
 				</tr>
 				</thead>
 				<tbody>
-				@foreach (var currentRow in this.ViewModel.VisibleRows)
+				@foreach (var currentRow in this.rowsToDisplay)
 				{
 					<tr class="@this.GetTrClass(currentRow)">
 						<th @onclick="() => this.ViewModel.SelectElement(currentRow)" id="row_@currentRow.ThingId">
@@ -38,15 +38,15 @@
 								@currentRow.Id
 							</span>
 						</th>
-							@foreach (var currentColumn in this.ViewModel.VisibleColumns)
-						{
-							<td class="@GetTdClass(currentRow, currentColumn)">
-								@if (this.ViewModel.GetRelationship(currentRow, currentColumn) is { } relationship)
-								{
-									<TraceabilityCell RelationshipRow="relationship" OnClick="(row) => this.ViewModel.SelectElement(row)"/>
-								}
-							</td>
-						}
+							@foreach (var currentColumn in this.columnsToDisplay)
+							{
+								<td class="@GetTdClass(currentRow, currentColumn)">
+									@if (this.ViewModel.GetRelationship(currentRow, currentColumn) is { } relationship)
+									{
+										<TraceabilityCell RelationshipRow="relationship" OnClick="(row) => this.ViewModel.SelectElement(row)"/>
+									}
+								</td>
+							}
 					</tr>
 				}
 				</tbody>

--- a/UI_DSM.Client/Components/NormalUser/Views/FunctionalTraceabilityToProductView.razor
+++ b/UI_DSM.Client/Components/NormalUser/Views/FunctionalTraceabilityToProductView.razor
@@ -30,9 +30,11 @@
 			<div class="interface-view-actions">
 				<div class="view-settings-panel">
 					<DxCheckBox CheckType="CheckType.Switch" @bind-Checked="@this.ViewModel.IsOnTechnologyView">Show Technology</DxCheckBox>
-
-						<h5>Row Traces</h5>
-						<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.VisibilityState" ConnectedStateText="with" NotConnectedStateText="without"/>
+					<h5>Row Traces</h5>
+					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.RowVisibilityState" ConnectedStateText="with" NotConnectedStateText="without"/>
+					
+					<h5>Column Traces</h5>
+					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.ColumnVisibilityState" ConnectedStateText="with" NotConnectedStateText="without" />
 				</div>
 			</div>
 		</BodyTemplate>

--- a/UI_DSM.Client/Components/NormalUser/Views/RequirementTraceabilityToFunctionView.razor
+++ b/UI_DSM.Client/Components/NormalUser/Views/RequirementTraceabilityToFunctionView.razor
@@ -29,7 +29,10 @@
 			<div class="interface-view-actions">
 				<div class="view-settings-panel">
 					<h5>Row Traces</h5>
-					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.VisibilityState" ConnectedStateText="with" NotConnectedStateText="without"/>
+					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.RowVisibilityState" ConnectedStateText="with" NotConnectedStateText="without"/>
+					
+					<h5>Column Traces</h5>
+					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.ColumnVisibilityState" ConnectedStateText="with" NotConnectedStateText="without" />
 				</div>
 			</div>
 		</BodyTemplate>

--- a/UI_DSM.Client/Components/NormalUser/Views/RequirementTraceabilityToProductView.razor
+++ b/UI_DSM.Client/Components/NormalUser/Views/RequirementTraceabilityToProductView.razor
@@ -30,9 +30,11 @@
 			<div class="interface-view-actions">
 				<div class="view-settings-panel">
 					<DxCheckBox CheckType="CheckType.Switch" @bind-Checked="@this.ViewModel.IsOnTechnologyView">Show Technology</DxCheckBox>
-
 					<h5>Row Traces</h5>
-					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.VisibilityState" ConnectedStateText="with" NotConnectedStateText="without"/>
+					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.RowVisibilityState" ConnectedStateText="with" NotConnectedStateText="without"/>
+					
+					<h5>Column Traces</h5>
+					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.ColumnVisibilityState" ConnectedStateText="with" NotConnectedStateText="without" />
 				</div>
 			</div>
 		</BodyTemplate>

--- a/UI_DSM.Client/Components/NormalUser/Views/RequirementTraceabilityToRequirementView.razor
+++ b/UI_DSM.Client/Components/NormalUser/Views/RequirementTraceabilityToRequirementView.razor
@@ -30,7 +30,10 @@
 			<div class="interface-view-actions">
 				<div class="view-settings-panel">
 					<h5>Row Traces</h5>
-					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.VisibilityState" ConnectedStateText="with" NotConnectedStateText="without"/>
+					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.RowVisibilityState" ConnectedStateText="with" NotConnectedStateText="without"/>
+					
+					<h5>Column Traces</h5>
+					<ConnectionVisibilitySelector ViewModel="this.ViewModel.TraceabilityTableViewModel.ColumnVisibilityState" ConnectedStateText="with" NotConnectedStateText="without" />
 				</div>
 			</div>
 		</BodyTemplate>

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ITraceabilityTableViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ITraceabilityTableViewModel.cs
@@ -62,9 +62,14 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         Func<IHaveThingRowViewModel, bool> IsValidRow { get; }
 
         /// <summary>
-        ///     The <see cref="IConnectionVisibilitySelectorViewModel" />
+        ///     The <see cref="IConnectionVisibilitySelectorViewModel" /> for rows
         /// </summary>
-        IConnectionVisibilitySelectorViewModel VisibilityState { get; }
+        IConnectionVisibilitySelectorViewModel RowVisibilityState { get; }
+
+        /// <summary>
+        ///     The <see cref="IConnectionVisibilitySelectorViewModel" /> for columns
+        /// </summary>
+        IConnectionVisibilitySelectorViewModel ColumnVisibilityState { get; }
 
         /// <summary>
         ///     Selects the current <see cref="IHaveThingRowViewModel" />
@@ -88,8 +93,16 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         ///     Verifies if the current <see cref="IHaveThingRowViewModel" /> trace any of the visible
         ///     <see cref="IHaveThingRowViewModel" /> column
         /// </summary>
-        /// <param name="row">The <see cref="IHaveTraceabilityTableViewModel" />The <see cref="IHaveThingRowViewModel" /></param>
+        /// <param name="row">The <see cref="IHaveTraceabilityTableViewModel" /></param>
         /// <returns>The result of the verification</returns>
         bool DoesRowTraceAnyColumns(IHaveThingRowViewModel row);
+
+        /// <summary>
+        ///     Verifies if the current <see cref="IHaveThingRowViewModel" /> column trace any of the visible
+        ///     <see cref="IHaveThingRowViewModel" /> row
+        /// </summary>
+        /// <param name="column">The <see cref="IHaveTraceabilityTableViewModel" /> column</param>
+        /// <returns>The result of the verification</returns>
+        bool DoesRowTraceAnyRows(IHaveThingRowViewModel column);
     }
 }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/TraceabilityTableViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/TraceabilityTableViewModel.cs
@@ -51,7 +51,12 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <summary>
         ///     The <see cref="IConnectionVisibilitySelectorViewModel" />
         /// </summary>
-        public IConnectionVisibilitySelectorViewModel VisibilityState { get; } = new ConnectionVisibilitySelectorViewModel();
+        public IConnectionVisibilitySelectorViewModel RowVisibilityState { get; } = new ConnectionVisibilitySelectorViewModel();
+
+        /// <summary>
+        ///     The <see cref="IConnectionVisibilitySelectorViewModel" /> for columns
+        /// </summary>
+        public IConnectionVisibilitySelectorViewModel ColumnVisibilityState { get; } = new ConnectionVisibilitySelectorViewModel();
 
         /// <summary>
         ///     A collection of visible rows
@@ -131,6 +136,17 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         public bool DoesRowTraceAnyColumns(IHaveThingRowViewModel row)
         {
             return this.VisibleColumns.Any(column => this.GetRelationship(row, column) != null);
+        }
+
+        /// <summary>
+        ///     Verifies if the current <see cref="IHaveThingRowViewModel" /> column trace any of the visible
+        ///     <see cref="IHaveThingRowViewModel" /> row
+        /// </summary>
+        /// <param name="column">The <see cref="IHaveTraceabilityTableViewModel" /> column</param>
+        /// <returns>The result of the verification</returns>
+        public bool DoesRowTraceAnyRows(IHaveThingRowViewModel column)
+        {
+            return this.VisibleRows.Any(row => this.GetRelationship(row, column) != null);
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/UI-DSM/pulls) open
- [x] I have verified that I am following the UI-DSM [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/UI-DSM/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #204 

Inside views with traceability, columns can be filtered also depending if they has traces or not, same as rows.
<!-- Thanks for contributing to UI-DSM! -->