### PR TITLE
The user menu contains the name of the current role: Fix  #233

### DIFF
--- a/UI_DSM.Client.Tests/Shared/TopMenu/TopMenuTestFixture.cs
+++ b/UI_DSM.Client.Tests/Shared/TopMenu/TopMenuTestFixture.cs
@@ -34,6 +34,7 @@ namespace UI_DSM.Client.Tests.Shared.TopMenu
     using UI_DSM.Client.Shared.TopMenu;
     using UI_DSM.Client.Tests.Helpers;
     using UI_DSM.Client.ViewModels.Shared.TopMenu;
+    using UI_DSM.Shared.Models;
 
     using TestContext = Bunit.TestContext;
 
@@ -87,6 +88,38 @@ namespace UI_DSM.Client.Tests.Shared.TopMenu
             await renderer.Instance.ViewModel.InitializesViewModel();
             renderer.Render();
             Assert.That(renderer.FindComponents<UserAvatar>(), Is.Not.Empty);
+
+            var projectId = Guid.NewGuid();
+
+            this.userService.Setup(x => x.GetParticipantsForUser()).ReturnsAsync(new List<Participant>
+            {
+                new ()
+                {
+                    Role = new Role()
+                    {
+                        RoleName = "Project Manager"
+                    },
+                    EntityContainer = new Project(projectId)
+                }
+            });
+
+            await renderer.InvokeAsync(renderer.Instance.OpenUserMenu);
+            renderer.Render();
+            Assert.That(() => renderer.Find("#roleName"), Throws.Exception);
+
+            await renderer.InvokeAsync(renderer.Instance.OpenUserMenu);
+            renderer.Render();
+            renderer.Instance.NavigationManager.NavigateTo($"/Project/{Guid.NewGuid()}");
+
+            await renderer.InvokeAsync(renderer.Instance.OpenUserMenu);
+            renderer.Render();
+            Assert.That(() => renderer.Find("#roleName"), Throws.Exception);
+            
+            await renderer.InvokeAsync(renderer.Instance.OpenUserMenu);
+            renderer.Render();
+            renderer.Instance.NavigationManager.NavigateTo($"/Project/{projectId}");
+
+            Assert.That(renderer.Instance.GetRoleName(), Is.Not.Empty);
         }
     }
 }

--- a/UI_DSM.Client/Shared/TopMenu/TopMenu.razor
+++ b/UI_DSM.Client/Shared/TopMenu/TopMenu.razor
@@ -37,7 +37,7 @@
 			<div id="user-icon-button">
 				@if (this.ViewModel.UserName != null)
 				{
-					<button @onclick="() => this.IsUserMenuOpen = !this.IsUserMenuOpen">
+					<button @onclick="this.OpenUserMenu">
 						<UserAvatar UserInitials="@this.ViewModel.UserName[0].ToString()"/>
 					</button>
 				}
@@ -49,6 +49,14 @@
 					CloseMode="DropDownCloseMode.Close"
 					PreventCloseOnPositionTargetClick="true"
 					BodyCssClass="account-dropdown">
+					@{
+						var roleName = this.GetRoleName();
+
+						if (!string.IsNullOrEmpty(roleName))
+						{
+							<p id="roleName">Role: @roleName</p>
+						}
+					}
 					<ul>
 						<AuthorizeView Roles="Administrator">
 							<Authorized>

--- a/UI_DSM.Client/Shared/TopMenu/TopMenu.razor.cs
+++ b/UI_DSM.Client/Shared/TopMenu/TopMenu.razor.cs
@@ -18,14 +18,15 @@ namespace UI_DSM.Client.Shared.TopMenu
     using ReactiveUI;
 
     using UI_DSM.Client.ViewModels.Shared.TopMenu;
+    using UI_DSM.Shared.Models;
 
     /// <summary>
     ///     The TopMenu component
     /// </summary>
-    public partial class TopMenu: IDisposable
+    public partial class TopMenu : IDisposable
     {
         /// <summary>
-        /// A collection of <see cref="IDisposable"/>
+        ///     A collection of <see cref="IDisposable" />
         /// </summary>
         private List<IDisposable> disposables = new();
 
@@ -34,6 +35,12 @@ namespace UI_DSM.Client.Shared.TopMenu
         /// </summary>
         [Inject]
         public ITopMenuViewModel ViewModel { get; set; }
+
+        /// <summary>
+        ///     The <see cref="NavigationManager" />
+        /// </summary>
+        [Inject]
+        public NavigationManager NavigationManager { get; set; }
 
         /// <summary>
         ///     Bool to keep track of the open state of the user dropdown menu
@@ -49,10 +56,24 @@ namespace UI_DSM.Client.Shared.TopMenu
         }
 
         /// <summary>
-        /// Method invoked when the component is ready to start, having received its
-        /// initial parameters from its parent in the render tree.
-        /// Override this method if you will perform an asynchronous operation and
-        /// want the component to refresh when that operation is completed.
+        ///     Opens the user menu
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        public async Task OpenUserMenu()
+        {
+            if (!this.IsUserMenuOpen)
+            {
+                await this.ViewModel.InitializesViewModel();
+            }
+
+            this.IsUserMenuOpen = !this.IsUserMenuOpen;
+        }
+
+        /// <summary>
+        ///     Method invoked when the component is ready to start, having received its
+        ///     initial parameters from its parent in the render tree.
+        ///     Override this method if you will perform an asynchronous operation and
+        ///     want the component to refresh when that operation is completed.
         /// </summary>
         /// <returns>A <see cref="T:System.Threading.Tasks.Task" /> representing any asynchronous operation.</returns>
         protected override Task OnInitializedAsync()
@@ -61,6 +82,33 @@ namespace UI_DSM.Client.Shared.TopMenu
                 .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
 
             return this.ViewModel.InitializesViewModel();
+        }
+
+        /// <summary>
+        ///     Gets the name of the current <see cref="Role" /> for the current <see cref="Project" />
+        /// </summary>
+        /// <returns>The name of the <see cref="Role" /></returns>
+        public string GetRoleName()
+        {
+            var projectId = this.GetProjectId();
+            return projectId != Guid.Empty ? this.ViewModel.GetRoleForProject(projectId) : string.Empty;
+        }
+
+        /// <summary>
+        ///     Gets the <see cref="Guid" /> of the <see cref="Project" /> based on the current url
+        /// </summary>
+        /// <returns>The <see cref="Guid" /></returns>
+        private Guid GetProjectId()
+        {
+            var url = new Uri(this.NavigationManager.Uri);
+            var splittedPath = url.LocalPath.Split('/');
+
+            if (splittedPath.Length < 3 || !Guid.TryParse(splittedPath[2], out var projectId))
+            {
+                return Guid.Empty;
+            }
+
+            return projectId;
         }
     }
 }

--- a/UI_DSM.Client/ViewModels/Shared/TopMenu/ITopMenuViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Shared/TopMenu/ITopMenuViewModel.cs
@@ -13,6 +13,8 @@
 
 namespace UI_DSM.Client.ViewModels.Shared.TopMenu
 {
+    using UI_DSM.Shared.Models;
+
     /// <summary>
     ///     Interface definition for <see cref="TopMenuViewModel" />
     /// </summary>
@@ -34,5 +36,12 @@ namespace UI_DSM.Client.ViewModels.Shared.TopMenu
         /// </summary>
         /// <returns>The assert</returns>
         bool HasAccessToProjectManagement();
+
+        /// <summary>
+        ///     Gets the <see cref="Role" /> name for the <see cref="Participant" /> for a <see cref="Project" />
+        /// </summary>
+        /// <param name="projectId">The <see cref="Project" /> id</param>
+        /// <returns>The name of the <see cref="Role" /></returns>
+        string GetRoleForProject(Guid projectId);
     }
 }

--- a/UI_DSM.Client/ViewModels/Shared/TopMenu/TopMenuViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Shared/TopMenu/TopMenuViewModel.cs
@@ -98,6 +98,17 @@ namespace UI_DSM.Client.ViewModels.Shared.TopMenu
         }
 
         /// <summary>
+        ///     Gets the <see cref="Role" /> name for the <see cref="Participant" /> for a <see cref="Project" />
+        /// </summary>
+        /// <param name="projectId">The <see cref="Project" /> id</param>
+        /// <returns>The name of the <see cref="Role" /></returns>
+        public string GetRoleForProject(Guid projectId)
+        {
+            var participant = this.participants.FirstOrDefault(x => x.EntityContainer.Id == projectId);
+            return participant?.Role.RoleName;
+        }
+
+        /// <summary>
         ///     Handle the change of authentication state
         /// </summary>
         /// <param name="state">The <see cref="AuthenticationState" /> Task</param>

--- a/UI_DSM.Server/Modules/UserModule.cs
+++ b/UI_DSM.Server/Modules/UserModule.cs
@@ -96,8 +96,10 @@ namespace UI_DSM.Server.Modules
         [Authorize]
         public async Task GetLinkedParticipants(IParticipantManager participantManager, HttpContext context)
         {
-            var participants = await participantManager.GetParticipants(context.User!.Identity!.Name);
-            await context.Response.Negotiate(participants.SelectMany(x => x.GetAssociatedEntities()).DistinctBy(x => x.Id).ToDtos());
+            var participants = (await participantManager.GetParticipants(context.User!.Identity!.Name)).ToList();
+            var entities = participants.SelectMany(x => x.GetAssociatedEntities()).ToList();
+            entities.AddRange(participants.Select(x => x.EntityContainer));
+            await context.Response.Negotiate(entities.DistinctBy(x => x.Id).ToDtos());
         }
 
         /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/UI-DSM/pulls) open
- [x] I have verified that I am following the UI-DSM [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/UI-DSM/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #233 

If the user is currently inside a project, the user menu contains the name of the role of the current participant.
<!-- Thanks for contributing to UI-DSM! -->