### PR TITLE
AccessRight for saving diagram created : Fix #219 #242 #243

### DIFF
--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/DocumentBasedTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/DocumentBasedTestFixture.cs
@@ -36,6 +36,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel;
     using UI_DSM.Shared.Models;
 
+    using Participant = UI_DSM.Shared.Models.Participant;
     using TestContext = Bunit.TestContext;
 
     [TestFixture]
@@ -199,7 +200,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                 var renderer = this.context.RenderComponent<DocumentBased>();
 
                 await renderer.Instance.InitializeViewModel(new List<Thing> { elementDefinition, otherElement, requirement, requirement2 }, projectId, reviewId, Guid.Empty,
-                    new List<string>{"aiv"}, new List<string>());
+                    new List<string>{"aiv"}, new List<string>(), new Participant());
 
                 Assert.Multiple(() =>
                 {

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/FunctionalBreakdownStructureViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/FunctionalBreakdownStructureViewTestFixture.cs
@@ -40,6 +40,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using ElementDefinition = CDP4Common.DTO.ElementDefinition;
     using ElementUsage = CDP4Common.DTO.ElementUsage;
     using Iteration = CDP4Common.DTO.Iteration;
+    using Participant = UI_DSM.Shared.Models.Participant;
     using Requirement = CDP4Common.EngineeringModelData.Requirement;
     using TestContext = Bunit.TestContext;
 
@@ -223,7 +224,8 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     .Select(x => x.Value)
                     .ToList();
 
-                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), new List<string>());
+                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), 
+                    new List<string>(), new Participant());
 
                 Assert.Multiple(() =>
                 {

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/FunctionalTraceabilityToProductViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/FunctionalTraceabilityToProductViewTestFixture.cs
@@ -38,6 +38,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views;
     using UI_DSM.Shared.Models;
 
+    using Participant = UI_DSM.Shared.Models.Participant;
     using TestContext = Bunit.TestContext;
 
     [TestFixture]
@@ -211,7 +212,8 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     .Select(x => x.Value)
                     .ToList();
 
-                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), new List<string>());
+                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), 
+                    new List<string>(), new Participant());
                 
                 Assert.Multiple(() =>
                 {

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/InterfaceViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/InterfaceViewTestFixture.cs
@@ -37,13 +37,16 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using UI_DSM.Client.ViewModels.App.ConnectionVisibilitySelector;
     using UI_DSM.Client.ViewModels.App.Filter;
     using UI_DSM.Client.ViewModels.App.OptionChooser;
+    using UI_DSM.Client.ViewModels.Components;
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views;
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel;
+    using UI_DSM.Shared.Enumerator;
     using UI_DSM.Shared.Models;
 
     using BinaryRelationship = CDP4Common.DTO.BinaryRelationship;
     using ElementDefinition = CDP4Common.DTO.ElementDefinition;
     using ElementUsage = CDP4Common.DTO.ElementUsage;
+    using Participant = UI_DSM.Shared.Models.Participant;
     using Requirement = CDP4Common.EngineeringModelData.Requirement;
     using TestContext = Bunit.TestContext;
 
@@ -60,7 +63,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
             this.context = new TestContext();
             this.context.ConfigureDevExpressBlazor();
             this.reviewItemService = new Mock<IReviewItemService>();
-            this.viewModel = new InterfaceViewViewModel(this.reviewItemService.Object, new FilterViewModel(), null);
+            this.viewModel = new InterfaceViewViewModel(this.reviewItemService.Object, new FilterViewModel(), null, new ErrorMessageViewModel());
             var trlViewModel = new ProductBreakdownStructureViewViewModel(this.reviewItemService.Object, new FilterViewModel(), new OptionChooserViewModel());
             this.context.Services.AddSingleton(this.viewModel);
             this.context.Services.AddTransient<IConnectionVisibilitySelectorViewModel, ConnectionVisibilitySelectorViewModel>();
@@ -203,7 +206,9 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     .Select(x => x.Value)
                     .ToList();
 
-                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), new List<string>());
+                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), 
+                    new List<string>(), new Participant(){Role = new Role(){AccessRights = { AccessRight.CreateDiagramConfiguration }}});
+
                 Assert.That(renderer.FindComponents<FeatherMessageCircle>(), Has.Count.EqualTo(1));
 
                 await renderer.InvokeAsync(() =>renderer.Instance.OnProductVisibilityChanged(true));

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/PhysicalFlowViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/PhysicalFlowViewTestFixture.cs
@@ -38,16 +38,18 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using UI_DSM.Client.Tests.Helpers;
     using UI_DSM.Client.ViewModels.App.ConnectionVisibilitySelector;
     using UI_DSM.Client.ViewModels.App.Filter;
+    using UI_DSM.Client.ViewModels.Components;
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views;
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel;
     
     using UI_DSM.Serializer.Json;
-    
+    using UI_DSM.Shared.Enumerator;
     using UI_DSM.Shared.Models;
 
     using BinaryRelationship = CDP4Common.DTO.BinaryRelationship;
     using ElementDefinition = CDP4Common.DTO.ElementDefinition;
     using ElementUsage = CDP4Common.DTO.ElementUsage;
+    using Participant = UI_DSM.Shared.Models.Participant;
     using TestContext = Bunit.TestContext;
 
     [TestFixture]
@@ -56,9 +58,6 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
         private IInterfaceViewViewModel viewModel;
         private Mock<IReviewItemService> reviewItemService;
         private TestContext context;
-
-        private readonly Uri uri = new Uri("http://test.com");
-
         private IRenderedComponent<PhysicalFlowView> renderer;
 
         [SetUp]
@@ -70,7 +69,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                 this.context.AddDevExpressBlazorTesting();
                 this.context.ConfigureDevExpressBlazor();
                 this.reviewItemService = new Mock<IReviewItemService>();
-                this.viewModel = new InterfaceViewViewModel(this.reviewItemService.Object, new FilterViewModel(), null);
+                this.viewModel = new InterfaceViewViewModel(this.reviewItemService.Object, new FilterViewModel(), null, new ErrorMessageViewModel());
                 this.context.Services.AddSingleton(this.viewModel);
 
                 this.context.Services.AddSingleton(this.viewModel);
@@ -220,9 +219,8 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     .Select(x => x.Value)
                     .ToList();
 
-                var reviewItem = new ReviewItem(Guid.NewGuid());
-
-                this.renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), new List<string>()).RunSynchronously();
+                this.renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), 
+                    new List<string>(), new Participant() { Role = new Role() { AccessRights = { AccessRight.CreateDiagramConfiguration } } }).RunSynchronously();
             }
             catch
             {
@@ -360,9 +358,9 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                 var anotherView = component.Instance;
 
                 var oldViewModel = anotherView.ViewModel;
-                this.context.JSInterop.Setup<int[]>("GetNodeDimensions").SetResult(new int[] { 100, 80 });
+                this.context.JSInterop.Setup<int[]>("GetNodeDimensions").SetResult(new [] { 100, 80 });
 
-                Task<bool> result = Task.FromResult(false);
+                var result = Task.FromResult(false);
                 await this.renderer.InvokeAsync(() => result = this.renderer.Instance.CopyComponents(anotherView));
                 var newViewModel = this.renderer.Instance.ViewModel;
 
@@ -385,9 +383,9 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
             var anotherView = component.Instance;
 
             var oldViewModel = anotherView.ViewModel;
-            this.context.JSInterop.Setup<int[]>("GetNodeDimensions").SetResult(new int[] { 100, 80 });
+            this.context.JSInterop.Setup<int[]>("GetNodeDimensions").SetResult(new [] { 100, 80 });
 
-            Task<bool> result = Task.FromResult(false);
+            var result = Task.FromResult(false);
             await this.renderer.InvokeAsync(() => result = this.renderer.Instance.CopyComponents(anotherView));
             var newViewModel = this.renderer.Instance.ViewModel;
 

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/PhysicalFlowViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/PhysicalFlowViewTestFixture.cs
@@ -13,6 +13,8 @@
 
 namespace UI_DSM.Client.Tests.Components.NormalUser.Views
 {
+    using AppComponents;
+
     using Blazor.Diagrams.Core.Geometry;
     using Blazor.Diagrams.Core.Models;
     using Blazor.Diagrams.Core.Models.Base;
@@ -25,14 +27,16 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using CDP4Dal;
     
     using CDP4JsonSerializer;
-    
+
     using Microsoft.Extensions.DependencyInjection;
 
     using Moq;
 
     using NUnit.Framework;
 
+    using UI_DSM.Client.Components.NormalUser.DiagrammingConfiguration;
     using UI_DSM.Client.Components.NormalUser.Views;
+    using UI_DSM.Client.Services.DiagrammingConfigurationService;
     using UI_DSM.Client.Services.JsonService;
     using UI_DSM.Client.Services.ReviewItemService;
     using UI_DSM.Client.Tests.Helpers;
@@ -41,8 +45,8 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using UI_DSM.Client.ViewModels.Components;
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views;
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel;
-    
     using UI_DSM.Serializer.Json;
+    using UI_DSM.Shared.DTO.Common;
     using UI_DSM.Shared.Enumerator;
     using UI_DSM.Shared.Models;
 
@@ -59,6 +63,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
         private Mock<IReviewItemService> reviewItemService;
         private TestContext context;
         private IRenderedComponent<PhysicalFlowView> renderer;
+        private Mock<IDiagrammingConfigurationService> diagramService;
 
         [SetUp]
         public void Setup()
@@ -69,7 +74,11 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                 this.context.AddDevExpressBlazorTesting();
                 this.context.ConfigureDevExpressBlazor();
                 this.reviewItemService = new Mock<IReviewItemService>();
-                this.viewModel = new InterfaceViewViewModel(this.reviewItemService.Object, new FilterViewModel(), null, new ErrorMessageViewModel());
+                this.diagramService = new Mock<IDiagrammingConfigurationService>();
+
+                this.viewModel = new InterfaceViewViewModel(this.reviewItemService.Object, new FilterViewModel(), this.diagramService.Object,
+                    new ErrorMessageViewModel());
+
                 this.context.Services.AddSingleton(this.viewModel);
 
                 this.context.Services.AddSingleton(this.viewModel);
@@ -220,7 +229,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     .ToList();
 
                 this.renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), 
-                    new List<string>(), new Participant() { Role = new Role() { AccessRights = { AccessRight.CreateDiagramConfiguration } } }).RunSynchronously();
+                    new List<string>(), new Participant() { Role = new Role() { AccessRights = { AccessRight.CreateDiagramConfiguration } } });
             }
             catch
             {
@@ -358,7 +367,8 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                 var anotherView = component.Instance;
 
                 var oldViewModel = anotherView.ViewModel;
-                this.context.JSInterop.Setup<int[]>("GetNodeDimensions").SetResult(new [] { 100, 80 });
+                this.context.JSInterop.Mode = JSRuntimeMode.Strict;
+                this.context.JSInterop.Setup<int[]>("GetNodeDimensions", _ => true).SetResult(new [] { 100, 80 });
 
                 var result = Task.FromResult(false);
                 await this.renderer.InvokeAsync(() => result = this.renderer.Instance.CopyComponents(anotherView));
@@ -461,6 +471,66 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
             this.renderer.Instance.MouseUpOnComponent(diagramNode);
             var lastSelectedElement = this.renderer.Instance.ViewModel.SelectedElement;
             Assert.That(lastSelectedElement, Is.Not.EqualTo(previousSelectedElement));
+        }
+
+        [Test]
+        public async Task VerifySaveDiagram()
+        {
+            this.renderer.Instance.IsLoading = false;
+            this.renderer.Render();
+            var buttons = this.renderer.FindComponents<AppButton>();
+            Assert.That(this.viewModel.IsOnSavingMode, Is.False);
+
+            await this.renderer.InvokeAsync(buttons[0].Instance.Click.InvokeAsync);
+            Assert.That(this.viewModel.IsOnSavingMode, Is.True);
+
+            this.diagramService.Setup(x => x.SaveDiagramLayout(It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<string>(), It.IsAny<IEnumerable<DiagramLayoutInformationDto>>())).ReturnsAsync((false,new List<string>{"Alreayd exist"}));
+
+            var creationDialog = this.renderer.FindComponent<DiagrammingConfigurationPopup>();
+            creationDialog.Instance.ViewModel.ConfigurationName = "a config";
+            await this.renderer.InvokeAsync(creationDialog.Instance.ViewModel.OnValidSubmit.InvokeAsync);
+            Assert.That(this.viewModel.IsOnSavingMode, Is.True);
+
+            this.diagramService.Setup(x => x.SaveDiagramLayout(It.IsAny<Guid>(), It.IsAny<Guid>(),
+                It.IsAny<string>(), It.IsAny<IEnumerable<DiagramLayoutInformationDto>>())).ReturnsAsync((true, new List<string>()));
+
+            await this.renderer.InvokeAsync(creationDialog.Instance.ViewModel.OnValidSubmit.InvokeAsync);
+            Assert.That(this.viewModel.IsOnSavingMode, Is.False);
+        }
+
+        [Test]
+        public async Task VerifyLoadDiagram()
+        {
+            this.renderer.Instance.IsLoading = false;
+            this.renderer.Render();
+            var buttons = this.renderer.FindComponents<AppButton>();
+            Assert.That(this.viewModel.IsOnLoadingMode, Is.False);
+
+            this.diagramService.Setup(x => x.LoadDiagramLayoutConfigurationNames(It.IsAny<Guid>(), It.IsAny<Guid>()))
+                .ReturnsAsync(new List<string> { "A config" });
+
+            await this.renderer.InvokeAsync(buttons[1].Instance.Click.InvokeAsync);
+            Assert.That(this.viewModel.IsOnLoadingMode, Is.True);
+
+            var creationDialog = this.renderer.FindComponent<DiagrammingConfigurationLoadingPopup>();
+            Assert.That(creationDialog.Instance.ViewModel.ConfigurationsName.ToList(), Has.Count.EqualTo(1));
+
+            creationDialog.Instance.ViewModel.SelectedConfiguration = "A config";
+
+            this.diagramService.Setup(x => x.LoadDiagramLayoutConfiguration(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string>()))
+                .ReturnsAsync(new List<DiagramLayoutInformationDto>
+                {
+                    new()
+                    {
+                        ThingId = this.viewModel.Products.First().ThingId,
+                        xPosition = 100,
+                        yPosition = 50
+                    }
+                });
+
+            await this.renderer.InvokeAsync(creationDialog.Instance.ViewModel.OnValidSubmit.InvokeAsync);
+            this.diagramService.Verify(x => x.LoadDiagramLayoutConfiguration(It.IsAny<Guid>(), It.IsAny<Guid>(), "A config"), Times.Once);
         }
     }
 }

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/ProductBreakdownStructureViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/ProductBreakdownStructureViewTestFixture.cs
@@ -36,6 +36,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views;
     using UI_DSM.Shared.Models;
 
+    using Participant = UI_DSM.Shared.Models.Participant;
     using TestContext = Bunit.TestContext;
 
     [TestFixture]
@@ -232,7 +233,8 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     .Select(x => x.Value)
                     .ToList();
 
-                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), new List<string>());
+                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), 
+                    new List<string>(), new Participant());
 
                 Assert.Multiple(() =>
                 {

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementBreakdownStructureViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementBreakdownStructureViewTestFixture.cs
@@ -34,6 +34,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel;
     using UI_DSM.Shared.Models;
 
+    using Participant = UI_DSM.Shared.Models.Participant;
     using TestContext = Bunit.TestContext;
 
     [TestFixture]
@@ -111,7 +112,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     .ReturnsAsync(reviewItems);
 
                 await renderer.InvokeAsync(() => renderer.Instance.InitializeViewModel(things, Guid.NewGuid(), Guid.NewGuid(), Guid.Empty,
-                    new List<string>{"space_debris"}, new List<string>()));
+                    new List<string>{"space_debris"}, new List<string>(), new Participant()));
 
                 Assert.Multiple(() =>
                 {

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewTestFixture.cs
@@ -36,6 +36,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views;
     using UI_DSM.Shared.Models;
 
+    using Participant = UI_DSM.Shared.Models.Participant;
     using TestContext = Bunit.TestContext;
     
     [TestFixture]
@@ -193,7 +194,8 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     .Select(x => x.Value)
                     .ToList();
 
-                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), new List<string>());
+                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), 
+                    new List<string>(), new Participant());
 
                 Assert.Multiple(() =>
                 {

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToProductViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToProductViewTestFixture.cs
@@ -45,6 +45,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using ElementUsage = CDP4Common.DTO.ElementUsage;
     using Parameter = CDP4Common.DTO.Parameter;
     using ParameterValueSet = CDP4Common.DTO.ParameterValueSet;
+    using Participant = UI_DSM.Shared.Models.Participant;
     using Requirement = CDP4Common.DTO.Requirement;
     using RequirementsSpecification = CDP4Common.DTO.RequirementsSpecification;
     using TestContext = Bunit.TestContext;
@@ -290,7 +291,8 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     .Select(x => x.Value)
                     .ToList();
 
-                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), new List<string>());
+                await renderer.Instance.InitializeViewModel(pocos, projectId, reviewId, Guid.Empty, new List<string>(), 
+                    new List<string>(), new Participant());
 
                 Assert.Multiple(() =>
                 {
@@ -315,7 +317,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                 Assert.Multiple(() =>
                 {
                     Assert.That(renderer.FindComponents<FeatherCheck>(), Has.Count.EqualTo(0));
-                    Assert.That(renderer.FindComponents<FeatherMessageCircle>(), Has.Count.EqualTo(1));
+                    Assert.That(renderer.FindComponents<FeatherMessageCircle>(), Has.Count.EqualTo(0));
                 });
 
                 this.viewModel.TraceabilityTableViewModel.RowVisibilityState.CurrentState = ConnectionToVisibilityState.All;

--- a/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToRequirementViewTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/Views/RequirementTraceabilityToRequirementViewTestFixture.cs
@@ -36,6 +36,7 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views;
     using UI_DSM.Shared.Models;
 
+    using Participant = UI_DSM.Shared.Models.Participant;
     using TestContext = Bunit.TestContext;
 
     [TestFixture]
@@ -153,7 +154,9 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.Views
                     });
 
                 var renderer = this.context.RenderComponent<RequirementTraceabilityToRequirementView>();
-                await renderer.Instance.InitializeViewModel(requirementsSpecification, projectId, reviewId, Guid.Empty, new List<string>(), new List<string>());
+
+                await renderer.Instance.InitializeViewModel(requirementsSpecification, projectId, reviewId, Guid.Empty, new List<string>(), 
+                    new List<string>(), new Participant());
 
                 Assert.Multiple(() =>
                 {

--- a/UI_DSM.Client.Tests/Pages/NormalUser/ReviewTaskPage/ReviewTaskPageTestFixture.cs
+++ b/UI_DSM.Client.Tests/Pages/NormalUser/ReviewTaskPage/ReviewTaskPageTestFixture.cs
@@ -40,6 +40,7 @@ namespace UI_DSM.Client.Tests.Pages.NormalUser.ReviewTaskPage
     using UI_DSM.Client.ViewModels.App.Filter;
     using UI_DSM.Client.ViewModels.App.OptionChooser;
     using UI_DSM.Client.ViewModels.App.SelectedItemCard;
+    using UI_DSM.Client.ViewModels.Components;
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views;
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel;
     using UI_DSM.Client.ViewModels.Pages.NormalUser.ReviewTaskPage;
@@ -116,7 +117,7 @@ namespace UI_DSM.Client.Tests.Pages.NormalUser.ReviewTaskPage
                 new ProductBreakdownStructureViewViewModel(new Mock<IReviewItemService>().Object, new FilterViewModel(), new OptionChooserViewModel());
 
             IInterfaceViewViewModel interfaceView =
-                new InterfaceViewViewModel(new Mock<IReviewItemService>().Object, new FilterViewModel(), null);
+                new InterfaceViewViewModel(new Mock<IReviewItemService>().Object, new FilterViewModel(), null, new ErrorMessageViewModel());
 
             this.context.Services.AddSingleton(breakdown);
             this.context.Services.AddSingleton(productBreakdown);

--- a/UI_DSM.Client/Components/Administration/ModelManagement/CometUpload.razor.cs
+++ b/UI_DSM.Client/Components/Administration/ModelManagement/CometUpload.razor.cs
@@ -103,10 +103,10 @@ namespace UI_DSM.Client.Components.Administration.ModelManagement
             switch (this.ViewModel.IterationUploadStatus)
             {
                 case UploadStatus.None:
-                    this.UploadText = "Upload";
+                    this.UploadText = "Connect";
                     break;
                 case UploadStatus.Uploading:
-                    this.UploadText = "Uploading";
+                    this.UploadText = "Connecting";
                     break;
                 case UploadStatus.Fail:
                     this.UploadText = "Retry...";

--- a/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityTable.razor.cs
+++ b/UI_DSM.Client/Components/App/TraceabilityTable/TraceabilityTable.razor.cs
@@ -105,6 +105,8 @@ namespace UI_DSM.Client.Components.App.TraceabilityTable
         public async Task Update()
         {
             this.ViewModel.UpdateTable();
+            await this.UpdateRowsToDisplay();
+            await this.UpdateColumnsToDisplay();
             await this.InvokeAsync(this.StateHasChanged);
         }
 

--- a/UI_DSM.Client/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationPopup.razor
+++ b/UI_DSM.Client/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationPopup.razor
@@ -10,10 +10,14 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 <DxFormLayout>
-	<DxFormLayoutItem Caption="Configuration Name:" ColSpanMd="12">
-		<DxTextBox @bind-Text="@this.ViewModel.ConfigurationName" NullText="Enter the name of the configuration to save" />
+	<DxFormLayoutItem Caption="Configuration Name (Max. 5 configurations):" ColSpanMd="12">
+		<DxTextBox @bind-Text="@this.ViewModel.ConfigurationName" 
+		           BindValueMode="BindValueMode.OnInput"
+		           NullText="Enter the name of the configuration to save" />
 	</DxFormLayoutItem>
+	<ErrorMessage />
 </DxFormLayout>
 <div class="modal-footer m-top-10px">
-	<DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" Click="@this.ViewModel.OnValidSubmit" Enabled="@(!(string.IsNullOrEmpty(this.ViewModel.ConfigurationName)))"/>
+	<DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Save" Click="@this.ViewModel.OnValidSubmit" 
+	          Enabled="@(!(string.IsNullOrEmpty(this.ViewModel.ConfigurationName)))"/>
 </div>

--- a/UI_DSM.Client/Components/NormalUser/Views/BaseView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/BaseView.razor.cs
@@ -53,10 +53,12 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         /// <param name="things">The collection of <see cref="Thing" /></param>
         /// <param name="projectId">The <see cref="Project" /> id</param>
         /// <param name="reviewId">The <see cref="Review" /> id</param>
+        /// <param name="reviewTaskId">The <see cref="ReviewTask"/> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant">The current <see cref="Participant"/></param>
         /// <returns>A <see cref="Task" /></returns>
-        public abstract Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart);
+        public abstract Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant);
 
         /// <summary>
         ///     Handle the fact that something has changed and needs to update the view

--- a/UI_DSM.Client/Components/NormalUser/Views/ElementBreakdownStructureView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/ElementBreakdownStructureView.razor.cs
@@ -99,11 +99,12 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant">The current <see cref="Participant"/></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
             this.hasAlreadyExpandOnce = false;
-            await base.InitializeViewModel(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeViewModel(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
             this.IsLoading = false;
         }
 

--- a/UI_DSM.Client/Components/NormalUser/Views/GenericBaseView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/GenericBaseView.razor.cs
@@ -73,10 +73,11 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
-        /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        /// <param name="participant">The current <see cref="Participant"/></param>
+        /// /// <returns>A <see cref="Task" /></returns>
+        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await this.ViewModel.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await this.ViewModel.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
             await this.HasChanged();
         }
 

--- a/UI_DSM.Client/Components/NormalUser/Views/HaveTechnologyView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/HaveTechnologyView.razor.cs
@@ -35,10 +35,11 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant">The current <see cref="Participant"/></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeViewModel(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeViewModel(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
             this.IsLoading = false;
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnTechnologyView)

--- a/UI_DSM.Client/Components/NormalUser/Views/HaveTraceabilityTableView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/HaveTraceabilityTableView.razor.cs
@@ -67,13 +67,14 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant">The current <see cref="Participant"/></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
             this.Disposables.Add(this.ViewModel);
             this.Disposables.Add(this.Table);
 
-            await this.ViewModel.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await this.ViewModel.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
             await this.Table.InitiliazeProperties(this.ViewModel.TraceabilityTableViewModel);
 
             this.Disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsViewSettingsVisible)

--- a/UI_DSM.Client/Components/NormalUser/Views/InterfaceView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/InterfaceView.razor.cs
@@ -90,10 +90,11 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant">The current <see cref="Participant"/></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeViewModel(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeViewModel(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
             this.IsLoading = false;
         }
 

--- a/UI_DSM.Client/Components/NormalUser/Views/PhysicalFlowView.razor
+++ b/UI_DSM.Client/Components/NormalUser/Views/PhysicalFlowView.razor
@@ -12,13 +12,16 @@
 @using Blazor.Diagrams.Components;
 @using UI_DSM.Client.Components.Widgets;
 @using UI_DSM.Client.Components.NormalUser.DiagrammingConfiguration;
+@using UI_DSM.Shared.Enumerator
 
 @inherits GenericBaseView<UI_DSM.Client.ViewModels.Components.NormalUser.Views.IInterfaceViewViewModel>
 
 <DxPopup CloseOnOutsideClick="false" HeaderText="Save Configuration" @bind-Visible="@this.ViewModel.IsOnSavingMode">
-    <Content>
-        <DiagrammingConfigurationPopup ViewModel="@this.ViewModel.DiagrammingConfigurationPopupViewModel" />
-    </Content>
+	<Content>
+		<CascadingValue Value="this.ViewModel.ErrorMessageViewModel">
+			<DiagrammingConfigurationPopup ViewModel="@this.ViewModel.DiagrammingConfigurationPopupViewModel"/>
+		</CascadingValue>
+	</Content>
 </DxPopup>
 
 <DxPopup CloseOnOutsideClick="false" HeaderText="Load Configuration" @bind-Visible="@this.ViewModel.IsOnLoadingMode">
@@ -29,15 +32,19 @@
 
 <CascadingValue Value="this.Diagram">
     <div id="diagram-parent" @ref="this.DiagramReference">
-        <LoadingComponent IsLoading="@this.IsLoading">
-            <DiagramCanvas></DiagramCanvas>
-            <DiagramLegendWidget></DiagramLegendWidget>
-            <AppButton Label="Save layout" Type="button" Variant="AppButton.VariantValue.Tertiary" Click="@this.ViewModel.OpenSavingPopup">
-                <FeatherSave Size="20" Color="currentColor" StrokeWidth="2" /> <span>Save</span>
-            </AppButton>
-            <AppButton Label="Load layout" Type="button" Variant="AppButton.VariantValue.Tertiary" Click="@this.ViewModel.OpenLoadingConfigurationPopup">
-                <FeatherUpload Size="20" Color="currentColor" StrokeWidth="2" /> <span>Load</span>
-            </AppButton>
-        </LoadingComponent>
+	    <LoadingComponent IsLoading="@this.IsLoading">
+		    @if (this.ViewModel.Participant.IsAllowedTo(AccessRight.CreateDiagramConfiguration))
+		    {
+			    <AppButton Label="Save layout" Type="button" Variant="AppButton.VariantValue.Tertiary" Click="@this.ViewModel.OpenSavingPopup">
+						<FeatherSave Size="20" Color="currentColor" StrokeWidth="2"/> <span>Save</span>
+			    </AppButton>
+		    }
+            
+		    <AppButton Label="Load layout" Type="button" Variant="AppButton.VariantValue.Tertiary" Click="@this.ViewModel.OpenLoadingConfigurationPopup">
+			    <FeatherUpload Size="20" Color="currentColor" StrokeWidth="2" /> <span>Load</span>
+		    </AppButton>
+		    <DiagramCanvas /> 
+		    <DiagramLegendWidget />
+	    </LoadingComponent>
     </div>
 </CascadingValue>

--- a/UI_DSM.Client/Components/NormalUser/Views/RequirementBreakdownStructureView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/RequirementBreakdownStructureView.razor.cs
@@ -86,10 +86,11 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant">The current <see cref="Participant"/></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeViewModel(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeViewModel(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeViewModel(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
             this.IsLoading = false;
 
             this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.FilterViewModel.IsFilterVisible)

--- a/UI_DSM.Client/Pages/Administration/ProjectPages/ProjectPage.razor
+++ b/UI_DSM.Client/Pages/Administration/ProjectPages/ProjectPage.razor
@@ -46,9 +46,9 @@
 		<ModelsDetails  ViewModel="@this.ViewModel.ProjectDetailsViewModel"/>		
 		<div>
 			<AppButton Click="@this.ViewModel.OpenCometConnectionPopup" Type="button">
-				<FeatherUpload Size="20" Color="currentColor" StrokeWidth="2"/> <span>Add COMET Model</span>
+				<FeatherUpload Size="20" Color="currentColor" StrokeWidth="2"/> <span>Connect to COMET</span>
 			</AppButton>
-			<DxPopup CloseOnOutsideClick="false" HeaderText="Upload an Iteration" @bind-Visible="@this.ViewModel.IsOnCometConnectionMode">
+			<DxPopup CloseOnOutsideClick="false" HeaderText="Connect to COMET" @bind-Visible="@this.ViewModel.IsOnCometConnectionMode">
 				<Content>
 					<CometUpload ViewModel="@this.ViewModel.CometUploadViewModel"/>
 				</Content>

--- a/UI_DSM.Client/Pages/NormalUser/ModelPage/ModelPage.razor.cs
+++ b/UI_DSM.Client/Pages/NormalUser/ModelPage/ModelPage.razor.cs
@@ -152,7 +152,9 @@ namespace UI_DSM.Client.Pages.NormalUser.ModelPage
                 this.ViewModel.CurrentBaseViewInstance = baseView;
                 this.DisposeViewDisposables();
                 var projectId = new Guid(this.ProjectId);
-                await baseView.InitializeViewModel(this.ViewModel.Things, projectId, Guid.Empty, Guid.Empty, new List<string>(), new List<string>());
+
+                await baseView.InitializeViewModel(this.ViewModel.Things, projectId, Guid.Empty, 
+                    Guid.Empty, new List<string>(), new List<string>(), null);
 
                 if (Guid.TryParse(this.Id, out var itemId))
                 {

--- a/UI_DSM.Client/Pages/NormalUser/ReviewTaskPage/ReviewTaskPage.razor.cs
+++ b/UI_DSM.Client/Pages/NormalUser/ReviewTaskPage/ReviewTaskPage.razor.cs
@@ -199,7 +199,9 @@ namespace UI_DSM.Client.Pages.NormalUser.ReviewTaskPage
 
                 if (baseView is not IReusableView reusableView || !await reusableView.CopyComponents(this.ViewModel.CurrentBaseViewInstance))
                 {
-                    await baseView.InitializeViewModel(this.ViewModel.Things, projectId, reviewId, reviewTaskId, this.ViewModel.GetPrefilters(), this.ViewModel.ReviewObjective.AdditionnalColumnsVisibleAtStart);
+                    await baseView.InitializeViewModel(this.ViewModel.Things, projectId, reviewId, reviewTaskId, this.ViewModel.GetPrefilters(), 
+                        this.ViewModel.ReviewObjective.AdditionnalColumnsVisibleAtStart, this.ViewModel.Participant);
+
                     baseView.TrySetSelectedItem(this.SelectedItem);
 
                     if (this.SelectedItem is IHaveThingRowViewModel row)
@@ -296,7 +298,7 @@ namespace UI_DSM.Client.Pages.NormalUser.ReviewTaskPage
                 if (this.ViewModel.CurrentBaseViewInstance != null)
                 {
                     await this.ViewModel.CurrentBaseViewInstance.InitializeViewModel(this.ViewModel.Things, projectId, reviewId, reviewTaskId, this.ViewModel.GetPrefilters(),
-                        this.ViewModel.ReviewObjective.AdditionnalColumnsVisibleAtStart);
+                        this.ViewModel.ReviewObjective.AdditionnalColumnsVisibleAtStart, this.ViewModel.Participant);
 
                     this.ViewModel.CurrentBaseViewInstance.TrySetSelectedItem(this.SelectedItem);
                 }

--- a/UI_DSM.Client/Services/DiagrammingConfigurationService/DiagrammingConfigurationService.cs
+++ b/UI_DSM.Client/Services/DiagrammingConfigurationService/DiagrammingConfigurationService.cs
@@ -37,19 +37,25 @@ namespace UI_DSM.Client.Services.DiagrammingConfigurationService
         /// <summary>
         ///     Saves <see cref="ReviewTask" /> diagram configuration
         /// </summary>
-        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" />
-        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" />
-        /// <param name="configurationName">The name of the configuration
+        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" /></param>
+        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" /></param>
+        /// <param name="configurationName">The name of the configuration</param>
         /// <param name="diagramLayoutInformation">The <see cref="IEnumerable{DiagramNode}" />to create</param>
-        /// <returns>A <see cref="Task" /> 
-        public async Task<bool> SaveDiagramLayout(Guid projectId, Guid reviewTaskId, string configurationName, IEnumerable<DiagramLayoutInformationDto> diagramLayoutInformation)
+        /// <returns>A <see cref="Task" /> </returns>
+        public async Task<(bool result, List<string> errors)> SaveDiagramLayout(Guid projectId, Guid reviewTaskId, string configurationName, IEnumerable<DiagramLayoutInformationDto> diagramLayoutInformation)
         {
             try
             {
                 var content = this.jsonService.Serialize(diagramLayoutInformation);
                 var bodyContent = new StringContent(content, Encoding.UTF8, "application/json");
                 var response = await this.HttpClient.PostAsync($"{this.MainRoute}/{projectId}/{reviewTaskId}/{configurationName}/Save", bodyContent);
-                return response.IsSuccessStatusCode;
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return (false, this.jsonService.Deserialize<List<string>>(await response.Content.ReadAsStreamAsync()));
+                }
+
+                return (response.IsSuccessStatusCode, new List<string>());
             }
             catch (Exception exception)
             {
@@ -60,9 +66,9 @@ namespace UI_DSM.Client.Services.DiagrammingConfigurationService
         /// <summary>
         ///     Loads diagram configurations name
         /// </summary>
-        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" />
-        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" />
-        /// <returns>A <see cref="Task" /> with the <see cref="List{string}" /></returns>
+        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" /></param>
+        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" /></param>
+        /// <returns>A <see cref="Task" /> with the <see cref="List{T}" /></returns>
         public async Task<List<string>> LoadDiagramLayoutConfigurationNames(Guid projectId, Guid reviewTaskId)
         {
             var response = await this.HttpClient.GetAsync($"{this.MainRoute}/{projectId}/{reviewTaskId}/Load");
@@ -71,16 +77,17 @@ namespace UI_DSM.Client.Services.DiagrammingConfigurationService
             {
                 throw new HttpRequestException(response.ReasonPhrase);
             }
-            var content = this.jsonService.Deserialize<List<String>>(await response.Content.ReadAsStreamAsync());
+            
+            var content = this.jsonService.Deserialize<List<string>>(await response.Content.ReadAsStreamAsync());
             return content;
         }
 
         /// <summary>
         ///     Loads <see cref="ReviewTask" /> diagram configuration
         /// </summary>
-        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" />
-        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" />
-        /// <param name="configurationName">The name of the selected configuration
+        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" /></param>
+        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" /></param>
+        /// <param name="configurationName">The name of the selected configuration</param>
         /// <returns>A <see cref="Task" /> with the <see cref="List{DiagramLayoutInformationDto}" /></returns>
         public async Task<List<DiagramLayoutInformationDto>> LoadDiagramLayoutConfiguration(Guid projectId, Guid reviewTaskId, string configurationName )
         {
@@ -90,6 +97,7 @@ namespace UI_DSM.Client.Services.DiagrammingConfigurationService
             {
                 throw new HttpRequestException(response.ReasonPhrase);
             }
+            
             var content = this.jsonService.Deserialize<List<DiagramLayoutInformationDto>>(await response.Content.ReadAsStreamAsync());
             return content;
         }

--- a/UI_DSM.Client/Services/DiagrammingConfigurationService/IDiagrammingConfigurationService.cs
+++ b/UI_DSM.Client/Services/DiagrammingConfigurationService/IDiagrammingConfigurationService.cs
@@ -24,27 +24,27 @@ namespace UI_DSM.Client.Services.DiagrammingConfigurationService
         /// <summary>
         ///     Saves <see cref="ReviewTask" /> diagram configuration
         /// </summary>
-        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" />
-        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" />
-        /// <param name="configurationName">The name of the configuration
+        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" /></param>
+        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" /></param>
+        /// <param name="configurationName">The name of the configuration</param>
         /// <param name="diagramLayoutInformation">The <see cref="IEnumerable{DiagramNode}" />to create</param>
-        /// <returns>A <see cref="Task" /> 
-        Task<bool> SaveDiagramLayout(Guid projectId, Guid reviewTaskId, string configurationName, IEnumerable<DiagramLayoutInformationDto> diagramLayoutInformation);
+        /// <returns>A <see cref="Task" /></returns>
+        Task<(bool result, List<string> errors)> SaveDiagramLayout(Guid projectId, Guid reviewTaskId, string configurationName, IEnumerable<DiagramLayoutInformationDto> diagramLayoutInformation);
 
         /// <summary>
         ///     Loads diagram configurations name
         /// </summary>
-        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" />
-        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" />
-        /// <returns>A <see cref="Task" /> with the <see cref="List{string}" /></returns>
+        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" /></param>
+        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" /></param>
+        /// <returns>A <see cref="Task" /> with the <see cref="List{T}" /></returns>
         Task<List<string>> LoadDiagramLayoutConfigurationNames(Guid projectId, Guid reviewTaskId);
 
         /// <summary>
         ///     Loads <see cref="ReviewTask" /> diagram configuration
         /// </summary>
-        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" />
-        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" />
-        /// <param name="configurationName">The name of the selected configuration
+        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" /></param>
+        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" /></param>
+        /// <param name="configurationName">The name of the selected configuration</param>
         /// <returns>A <see cref="Task" /> with the <see cref="List{DiagramLayoutInformationDto}" /></returns>
         Task<List<DiagramLayoutInformationDto>> LoadDiagramLayoutConfiguration(Guid projectId, Guid reviewTaskId, string configurationName);
     }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/BaseViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/BaseViewViewModel.cs
@@ -63,14 +63,19 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         protected Guid ReviewTaskId { get; private set; }
 
         /// <summary>
-        ///     A collection of columns name that can be visible by default at start
-        /// </summary>
-        public List<string> AdditionnalColumnsVisibleAtStart { get; protected set; }
-
-        /// <summary>
         ///     A collection of prefilters
         /// </summary>
         protected List<string> Prefilters { get; set; }
+
+        /// <summary>
+        ///     The current <see cref="Participant" />
+        /// </summary>
+        public Participant Participant { get; private set; }
+
+        /// <summary>
+        ///     A collection of columns name that can be visible by default at start
+        /// </summary>
+        public List<string> AdditionnalColumnsVisibleAtStart { get; protected set; }
 
         /// <summary>
         ///     A collection of <see cref="Thing" />
@@ -95,8 +100,10 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant">The current <see cref="Participant" /></param>
         /// <returns>A <see cref="Task" /></returns>
-        public virtual Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public virtual Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId,
+            List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
             this.Things = things;
             this.ProjectId = projectId;
@@ -104,6 +111,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
             this.ReviewTaskId = reviewTaskId;
             this.Prefilters = prefilters;
             this.AdditionnalColumnsVisibleAtStart = additionnalColumnsVisibleAtStart;
+            this.Participant = participant;
             return Task.CompletedTask;
         }
 

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/DocumentBasedViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/DocumentBasedViewModel.cs
@@ -40,7 +40,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         ///     A collection of <see cref="HyperLinkRowViewModel" />
         /// </summary>
         public IEnumerable<HyperLinkRowViewModel> Rows { get; private set; } = new List<HyperLinkRowViewModel>();
-        
+
         /// <summary>
         ///     Initialize this view model properties
         /// </summary>
@@ -50,10 +50,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             var hyperlinks= this.Things.OfType<ElementDefinition>()
                 .Where(x => x.HyperLink.Any() && x.HasValidReviewExternalContent(this.Prefilters))

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ElementBreakdownStructureViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ElementBreakdownStructureViewViewModel.cs
@@ -108,10 +108,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             this.OptionChooserViewModel.InitializesViewModel(this.Things.OfType<Option>().OrderBy(x => x.RevisionNumber).ToList());
         }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/FunctionalBreakdownStructureViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/FunctionalBreakdownStructureViewViewModel.cs
@@ -50,10 +50,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             var topElement = this.Things.OfType<Iteration>()
                 .SingleOrDefault()?.TopElement;

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/FunctionalTraceabilityToProductViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/FunctionalTraceabilityToProductViewViewModel.cs
@@ -77,10 +77,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             var functions = this.Things.OfType<ElementUsage>()
                 .Where(x => x.IsFunction())

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IBaseViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IBaseViewViewModel.cs
@@ -39,6 +39,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         List<string> AdditionnalColumnsVisibleAtStart { get; }
 
         /// <summary>
+        ///     The current <see cref="Participant" />
+        /// </summary>
+        Participant Participant { get; }
+
+        /// <summary>
         ///     Initialize this view model properties
         /// </summary>
         /// <param name="things">A collection of <see cref="Thing" /></param>
@@ -47,8 +52,9 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart);
+        Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant);
 
         /// <summary>
         ///     Tries to set the <see cref="SelectedElement" /> to the previous selected item

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IInterfaceViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IInterfaceViewViewModel.cs
@@ -13,9 +13,9 @@
 
 namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
 {
-    using Blazor.Diagrams.Core;
     using Blazor.Diagrams.Core.Geometry;
     using Blazor.Diagrams.Core.Models;
+    using Blazor.Diagrams.Core.Models.Base;
 
     using CDP4Common.CommonData;
 
@@ -42,7 +42,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         List<ProductRowViewModel> Products { get; }
 
         /// <summary>
-        /// Gets or sets the center point of the diagram
+        ///     Gets or sets the center point of the diagram
         /// </summary>
         Point DiagramCenter { get; set; }
 
@@ -72,17 +72,17 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         bool IsViewSettingsVisible { get; set; }
 
         /// <summary>
-        /// The map collection from <see cref="NodeModel"/> ID to <see cref="ProductRowViewModel"/>
+        ///     The map collection from <see cref="NodeModel" /> ID to <see cref="ProductRowViewModel" />
         /// </summary>
         Dictionary<DiagramNode, ProductRowViewModel> ProductsMap { get; }
 
         /// <summary>
-        /// The map collection from <see cref="PortModel"/> ID to <see cref="PortRowViewModel"/>
+        ///     The map collection from <see cref="PortModel" /> ID to <see cref="PortRowViewModel" />
         /// </summary>
         Dictionary<DiagramPort, PortRowViewModel> PortsMap { get; }
 
         /// <summary>
-        /// The map collection from <see cref="LinkModel"/> ID to <see cref="InterfaceRowViewModel"/>
+        ///     The map collection from <see cref="LinkModel" /> ID to <see cref="InterfaceRowViewModel" />
         /// </summary>
         Dictionary<DiagramLink, InterfaceRowViewModel> InterfacesMap { get; }
 
@@ -90,6 +90,31 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         ///     The <see cref="IFilterViewModel" />
         /// </summary>
         IFilterViewModel FilterViewModel { get; }
+
+        /// <summary>
+        ///     Value indicating the user is currently saving the diagramming configuration
+        /// </summary>
+        bool IsOnSavingMode { get; set; }
+
+        /// <summary>
+        ///     Value indicating the user is currently loading a diagramming configuration
+        /// </summary>
+        bool IsOnLoadingMode { get; set; }
+
+        /// <summary>
+        ///     The <see cref="IDiagrammingConfigurationPopupViewModel" />
+        /// </summary>
+        IDiagrammingConfigurationPopupViewModel DiagrammingConfigurationPopupViewModel { get; }
+
+        /// <summary>
+        ///     The <see cref="IDiagrammingConfigurationLoadingPopupViewModel" />
+        /// </summary>
+        IDiagrammingConfigurationLoadingPopupViewModel DiagrammingConfigurationLoadingPopupViewModel { get; }
+
+        /// <summary>
+        ///     The <see cref="IErrorMessageViewModel" />
+        /// </summary>
+        IErrorMessageViewModel ErrorMessageViewModel { get; }
 
         /// <summary>
         ///     Filters current rows
@@ -137,81 +162,64 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         void SetProductsVisibility(bool visibility);
 
         /// <summary>
-        /// Initializes the diagram with the selected element as a center node.
+        ///     Initializes the diagram with the selected element as a center node.
         /// </summary>
         void InitializeDiagram();
 
         /// <summary>
-        /// Selects the first central product depending on the selected element.
+        ///     Selects the first central product depending on the selected element.
         /// </summary>
         /// <param name="selectedElement">the selected element</param>
-        /// <returns>the selected <see cref="ProductRowViewModel"/></returns>
-        /// <exception cref="ArgumentException">if the selected element is not null and is not of type <see cref="ElementBaseRowViewModel"/></exception>
+        /// <returns>the selected <see cref="ProductRowViewModel" /></returns>
+        /// <exception cref="ArgumentException">
+        ///     if the selected element is not null and is not of type
+        ///     <see cref="ElementBaseRowViewModel" />
+        /// </exception>
         ProductRowViewModel SelectFirstProductByCloserSelectedItem(object selectedElement);
 
         /// <summary>
-        /// Tries to get all the neighbours of a <see cref="ProductRowViewModel"/>
+        ///     Tries to get all the neighbours of a <see cref="ProductRowViewModel" />
         /// </summary>
         /// <param name="productRow">the product to get the neighbours from</param>
-        /// <returns>A <see cref="IEnumerable{ProductRowViewModel}"/> with the neighbours, or null if the product don't have neighbours</returns>
+        /// <returns>A <see cref="IEnumerable{ProductRowViewModel}" /> with the neighbours, or null if the product don't have neighbours</returns>
         /// <exception cref="Exception">if the source and target of a interface it's the same port</exception>
         IEnumerable<ProductRowViewModel> GetNeighbours(ProductRowViewModel productRow);
 
         /// <summary>
-        /// Creates a central node and his neighbours
+        ///     Creates a central node and his neighbours
         /// </summary>
         /// <param name="centerNode">the center node</param>
         void CreateCentralNodeAndNeighbours(ProductRowViewModel centerNode);
 
         /// <summary>
-        /// Creates neighbours for a product a place them in circle 
+        ///     Creates neighbours for a product a place them in circle
         /// </summary>
-        /// <param name="productRowViewModel">the <see cref="ProductRowViewModel"/></param>
+        /// <param name="productRowViewModel">the <see cref="ProductRowViewModel" /></param>
         void CreateNeighboursAndPositionAroundProduct(ProductRowViewModel productRowViewModel);
 
         /// <summary>
-        /// Creates a new node from a <see cref="ProductRowViewModel"/>. The product is added to the Diagram an the corresponding maps are filled.
+        ///     Creates a new node from a <see cref="ProductRowViewModel" />. The product is added to the Diagram an the corresponding maps are filled.
         /// </summary>
         /// <param name="product">the product for which the node will be created</param>
-        /// <returns>the created <see cref="NodeModel"/></returns>
+        /// <returns>the created <see cref="NodeModel" /></returns>
         DiagramNode CreateNewNodeFromProduct(ProductRowViewModel product);
 
         /// <summary>
-        /// Creates the links for the <see cref="InterfaceRowViewModel"/>
+        ///     Creates the links for the <see cref="InterfaceRowViewModel" />
         /// </summary>
         void CreateInterfacesLinks();
 
         /// <summary>
-        /// Sets the selected model for this <see cref="IInterfaceViewViewModel"/>
+        ///     Sets the selected model for this <see cref="IInterfaceViewViewModel" />
         /// </summary>
         /// <param name="model">the model to select</param>
-        void SetSelectedModel(Blazor.Diagrams.Core.Models.Base.Model model);
+        void SetSelectedModel(Model model);
 
         /// <summary>
-        /// Upgrades the nodes with the actual data
+        ///     Upgrades the nodes with the actual data
         /// </summary>
         /// <returns>true if the object was updated, false otherwise</returns>
         bool TryUpdate(object updatedObject, bool hasComments);
-
-        /// <summary>
-        ///     Value indicating the user is currently saving the diagramming configuration
-        /// </summary>
-        bool IsOnSavingMode { get; set; }
-
-        /// <summary>
-        ///     Value indicating the user is currently loading a diagramming configuration
-        /// </summary>
-        bool IsOnLoadingMode { get; set; }
-
-        /// <summary>
-        ///     The <see cref="IDiagrammingConfigurationPopupViewModel" />
-        /// </summary>
-        IDiagrammingConfigurationPopupViewModel DiagrammingConfigurationPopupViewModel { get; }
-
-        /// <summary>
-        ///     The <see cref="IDiagrammingConfigurationLoadingPopupViewModel" />
-        /// </summary>
-        IDiagrammingConfigurationLoadingPopupViewModel DiagrammingConfigurationLoadingPopupViewModel { get; }
 
         /// <summary>
         ///     Opens the <see cref="DiagrammingConfigurationPopup" />

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/InterfaceViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/InterfaceViewViewModel.cs
@@ -98,8 +98,8 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewItemService">The <see cref="IReviewItemService" /></param>
         /// <param name="filterViewModel">The <see cref="IFilterViewModel" /></param>
         /// <param name="diagrammingConfigurationService">The <see cref="IDiagrammingConfigurationService" /></param>
-        /// <param name="errorMessageViewModel">The <see cref="IErrorMessageViewModel"/></param>
-        public InterfaceViewViewModel(IReviewItemService reviewItemService, IFilterViewModel filterViewModel, 
+        /// <param name="errorMessageViewModel">The <see cref="IErrorMessageViewModel" /></param>
+        public InterfaceViewViewModel(IReviewItemService reviewItemService, IFilterViewModel filterViewModel,
             IDiagrammingConfigurationService diagrammingConfigurationService, IErrorMessageViewModel errorMessageViewModel) : base(reviewItemService)
         {
             this.FilterViewModel = filterViewModel;
@@ -270,6 +270,48 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
             {
                 OnValidSubmit = new EventCallbackFactory().Create(this, this.LoadDiagramLayout)
             };
+        }
+
+        /// <summary>
+        ///     The <see cref="IDiagrammingConfigurationPopupViewModel" />
+        /// </summary>
+        public IDiagrammingConfigurationPopupViewModel DiagrammingConfigurationPopupViewModel { get; private set; }
+
+        /// <summary>
+        ///     The <see cref="IDiagrammingConfigurationLoadingPopupViewModel" />
+        /// </summary>
+        public IDiagrammingConfigurationLoadingPopupViewModel DiagrammingConfigurationLoadingPopupViewModel { get; private set; }
+
+        /// <summary>
+        ///     The <see cref="IErrorMessageViewModel" />
+        /// </summary>
+        public IErrorMessageViewModel ErrorMessageViewModel { get; }
+
+        /// <summary>
+        ///     Value indicating the user is currently saving the diagramming configuration
+        /// </summary>
+        public bool IsOnSavingMode
+        {
+            get => this.isOnSavingMode;
+            set => this.RaiseAndSetIfChanged(ref this.isOnSavingMode, value);
+        }
+
+        /// <summary>
+        ///     Value indicating the user is currently loading the diagramming configuration
+        /// </summary>
+        public bool IsOnLoadingMode
+        {
+            get => this.isOnLoadingMode;
+            set => this.RaiseAndSetIfChanged(ref this.isOnLoadingMode, value);
+        }
+
+        /// <summary>
+        ///     Opens the <see cref="DiagrammingConfigurationPopup" />
+        /// </summary>
+        public void OpenSavingPopup()
+        {
+            this.ErrorMessageViewModel.Errors.Clear();
+            this.IsOnSavingMode = true;
         }
 
         /// <summary>
@@ -669,48 +711,6 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
             }
 
             return false;
-        }
-
-        /// <summary>
-        ///     The <see cref="IDiagrammingConfigurationPopupViewModel" />
-        /// </summary>
-        public IDiagrammingConfigurationPopupViewModel DiagrammingConfigurationPopupViewModel { get; private set; }
-
-        /// <summary>
-        ///     The <see cref="IDiagrammingConfigurationLoadingPopupViewModel" />
-        /// </summary>
-        public IDiagrammingConfigurationLoadingPopupViewModel DiagrammingConfigurationLoadingPopupViewModel { get; private set; }
-
-        /// <summary>
-        ///     The <see cref="IErrorMessageViewModel" />
-        /// </summary>
-        public IErrorMessageViewModel ErrorMessageViewModel { get; }
-
-        /// <summary>
-        ///     Value indicating the user is currently saving the diagramming configuration
-        /// </summary>
-        public bool IsOnSavingMode
-        {
-            get => this.isOnSavingMode;
-            set => this.RaiseAndSetIfChanged(ref this.isOnSavingMode, value);
-        }
-
-        /// <summary>
-        ///     Value indicating the user is currently loading the diagramming configuration
-        /// </summary>
-        public bool IsOnLoadingMode
-        {
-            get => this.isOnLoadingMode;
-            set => this.RaiseAndSetIfChanged(ref this.isOnLoadingMode, value);
-        }
-
-        /// <summary>
-        ///     Opens the <see cref="DiagrammingConfigurationPopup" />
-        /// </summary>
-        public void OpenSavingPopup()
-        {
-            this.ErrorMessageViewModel.Errors.Clear();
-            this.IsOnSavingMode = true;
         }
 
         /// <summary>

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/InterfaceViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/InterfaceViewViewModel.cs
@@ -19,7 +19,9 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
 
     using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
+
     using DynamicData;
+
     using Microsoft.AspNetCore.Components;
 
     using ReactiveUI;
@@ -71,14 +73,14 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         private List<ProductRowViewModel> filteredProducts;
 
         /// <summary>
-        ///     Backing field for <see cref="IsOnSavingMode" />
-        /// </summary>
-        private bool isOnSavingMode;
-
-        /// <summary>
         ///     Backing field for <see cref="IsOnLoadingMode" />
         /// </summary>
         private bool isOnLoadingMode;
+
+        /// <summary>
+        ///     Backing field for <see cref="IsOnSavingMode" />
+        /// </summary>
+        private bool isOnSavingMode;
 
         /// <summary>
         ///     Backing field for <see cref="IsViewSettingsVisible" />
@@ -95,11 +97,14 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// </summary>
         /// <param name="reviewItemService">The <see cref="IReviewItemService" /></param>
         /// <param name="filterViewModel">The <see cref="IFilterViewModel" /></param>
-        /// <param name="diagrammingConfigurationService">The <see cref="IDiagrammingConfigurationService"/></param>
-        public InterfaceViewViewModel(IReviewItemService reviewItemService, IFilterViewModel filterViewModel, IDiagrammingConfigurationService diagrammingConfigurationService) : base(reviewItemService)
+        /// <param name="diagrammingConfigurationService">The <see cref="IDiagrammingConfigurationService" /></param>
+        /// <param name="errorMessageViewModel">The <see cref="IErrorMessageViewModel"/></param>
+        public InterfaceViewViewModel(IReviewItemService reviewItemService, IFilterViewModel filterViewModel, 
+            IDiagrammingConfigurationService diagrammingConfigurationService, IErrorMessageViewModel errorMessageViewModel) : base(reviewItemService)
         {
             this.FilterViewModel = filterViewModel;
             this.diagrammingConfigurationService = diagrammingConfigurationService;
+            this.ErrorMessageViewModel = errorMessageViewModel;
         }
 
         /// <summary>
@@ -166,9 +171,9 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         public Dictionary<DiagramLink, InterfaceRowViewModel> InterfacesMap { get; } = new();
 
         /// <summary>
-        /// Gets or sets the center of the diagram.
+        ///     Gets or sets the center of the diagram.
         /// </summary>
-        public Point DiagramCenter { get; set; } = new Point(800, 800);
+        public Point DiagramCenter { get; set; } = new(800, 800);
 
         /// <summary>
         ///     Filters current rows
@@ -209,13 +214,14 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="things">A collection of <see cref="Thing" /></param>
         /// <param name="projectId">The <see cref="Project" /> id</param>
         /// <param name="reviewId">The <see cref="Review" /> id</param>
-        /// <param name="reviewTaskId">The <see cref="ReviewTask"/> id</param>
+        /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             var products = this.Things.OfType<ElementDefinition>()
                 .Where(x => x.IsProduct())
@@ -368,10 +374,10 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         }
 
         /// <summary>
-        /// Selects the first central product depending on the selected element.
+        ///     Selects the first central product depending on the selected element.
         /// </summary>
         /// <param name="selectedElement">the selected element</param>
-        /// <returns>the selected <see cref="ProductRowViewModel"/></returns>
+        /// <returns>the selected <see cref="ProductRowViewModel" /></returns>
         /// <exception cref="ArgumentException">if the selected element is not null and is not of correct type</exception>
         public ProductRowViewModel SelectFirstProductByCloserSelectedItem(object selectedElement)
         {
@@ -379,30 +385,31 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
             {
                 return productRowViewModel;
             }
-            else if (selectedElement is PortRowViewModel portRowViewModel)
+
+            if (selectedElement is PortRowViewModel portRowViewModel)
             {
                 return this.Products.FirstOrDefault(x => x.ThingId == portRowViewModel.ContainerId, this.Products.First());
             }
-            else if (selectedElement is InterfaceRowViewModel interfaceRowViewModel)
+
+            if (selectedElement is InterfaceRowViewModel interfaceRowViewModel)
             {
                 var source = this.allPorts.FirstOrDefault(x => x.ThingId == interfaceRowViewModel.SourceId, this.allPorts.First());
                 return this.Products.FirstOrDefault(x => x.ThingId == source.ContainerId, this.Products.First());
             }
-            else if (selectedElement is null)
+
+            if (selectedElement is null)
             {
                 return this.Products.First();
             }
-            else
-            {
-                throw new ArgumentException($"the {selectedElement} is not a valid argument");
-            }
+
+            throw new ArgumentException($"the {selectedElement} is not a valid argument");
         }
 
         /// <summary>
-        /// Tries to get all the neighbours of a <see cref="ProductRowViewModel"/>
+        ///     Tries to get all the neighbours of a <see cref="ProductRowViewModel" />
         /// </summary>
         /// <param name="productRow">the product to get the neighbours from</param>
-        /// <returns>A <see cref="IEnumerable{ProductRowViewModel}"/> with the neighbours, or null if the product don't have neighbours</returns>
+        /// <returns>A <see cref="IEnumerable{ProductRowViewModel}" /> with the neighbours, or null if the product don't have neighbours</returns>
         /// <exception cref="Exception">if the source and target of a interface it's the same port</exception>
         public IEnumerable<ProductRowViewModel> GetNeighbours(ProductRowViewModel productRow)
         {
@@ -413,14 +420,15 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
 
                 foreach (var port in ports)
                 {
-                    var sourceInterface = this.Interfaces.FirstOrDefault(x => (x.SourceId == port.ThingId) && x.IsVisible, null);
-                    var targetInterface = this.Interfaces.FirstOrDefault(x => (x.TargetId == port.ThingId) && x.IsVisible, null);
+                    var sourceInterface = this.Interfaces.FirstOrDefault(x => x.SourceId == port.ThingId && x.IsVisible, null);
+                    var targetInterface = this.Interfaces.FirstOrDefault(x => x.TargetId == port.ThingId && x.IsVisible, null);
 
                     if (sourceInterface != null && targetInterface != null)
                     {
                         throw new Exception("Source and Target of an interface shall be a different port");
                     }
-                    else if (sourceInterface != null)
+
+                    if (sourceInterface != null)
                     {
                         var targetPort = this.allPorts.FirstOrDefault(p => p.ThingId == sourceInterface.TargetId, null);
 
@@ -437,6 +445,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
                     else if (targetInterface != null)
                     {
                         var sourcePort = this.allPorts.FirstOrDefault(p => p.ThingId == targetInterface.SourceId, null);
+
                         if (sourcePort != null)
                         {
                             var sourcePortContainer = this.Products.FirstOrDefault(pr => pr.ThingId == sourcePort.ContainerId, null);
@@ -478,23 +487,23 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <summary>
         ///     Creates a central node and his neighbours
         /// </summary>
-        /// <param name="centerNode">the center node</param>
+        /// <param name="centerProduct">the center node</param>
         public void CreateCentralNodeAndNeighbours(ProductRowViewModel centerProduct)
         {
             this.ProductsMap.Clear();
             this.PortsMap.Clear();
             this.InterfacesMap.Clear();
 
-            var node = CreateNewNodeFromProduct(centerProduct);
+            var node = this.CreateNewNodeFromProduct(centerProduct);
             node.SetPosition(this.DiagramCenter.X, this.DiagramCenter.Y);
 
             this.CreateNeighboursAndPositionAroundProduct(centerProduct);
         }
 
         /// <summary>
-        /// Creates neighbours for a product a place them in circle 
+        ///     Creates neighbours for a product a place them in circle
         /// </summary>
-        /// <param name="productRowViewModel">the <see cref="ProductRowViewModel"/></param>
+        /// <param name="productRowViewModel">the <see cref="ProductRowViewModel" /></param>
         public void CreateNeighboursAndPositionAroundProduct(ProductRowViewModel productRowViewModel)
         {
             if (this.ProductsMap.ContainsValue(productRowViewModel))
@@ -508,19 +517,20 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
                 if (neighbours != null && neighbours.Any())
                 {
                     var angle = Math.PI / 2.0;
-                    var angleIncrement = (2.0 * Math.PI) / neighbours.Count();
+                    var angleIncrement = 2.0 * Math.PI / neighbours.Count();
 
                     foreach (var neighbour in neighbours)
                     {
                         var x = node.Position.X - r * Math.Cos(angle);
                         var y = node.Position.Y - r * Math.Sin(angle);
 
-                        var neighbourNode = CreateNewNodeFromProduct(neighbour);
+                        var neighbourNode = this.CreateNewNodeFromProduct(neighbour);
                         neighbourNode.SetPosition(x, y);
 
                         angle += angleIncrement;
                     }
                 }
+
                 this.CreateInterfacesLinks();
             }
         }
@@ -549,6 +559,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
             if (this.HasChildren(product) && nodeCanBeAdded)
             {
                 var ports = this.LoadChildren(product);
+
                 foreach (var port in ports)
                 {
                     var index = ports.IndexOf(port);
@@ -573,56 +584,9 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
 
                     this.PortsMap.TryAdd(portNode, port);
                 }
-            }        
+            }
 
             return node;
-        }
-
-        /// <summary>
-        /// Gets the aproximate alignment of the port depending its position in the node
-        /// </summary>
-        /// <param name="indexOfPort">the index of the port</param>
-        /// <param name="totalPortsInNode"></param>
-        /// <returns>the aproximate alignment of the port</returns>
-        private static PortAlignment GetAproximateAlignment(int indexOfPort, int totalPortsInNode)
-        {
-            var increment = (360.0) / totalPortsInNode;
-            var angle = increment * indexOfPort;
-
-            if (angle >= 0 && angle < 22.5 || angle >= 337.5 && angle < 360.0)
-            {
-                return PortAlignment.Right;
-            }
-            else if (angle >= 22.5 && angle < 67.5)
-            {
-                return PortAlignment.TopRight;
-            }
-            else if (angle >= 67.5 && angle < 112.5)
-            {
-                return PortAlignment.Top;
-            }
-            else if (angle >= 112.5 && angle < 157.5)
-            {
-                return PortAlignment.TopLeft;
-            }
-            else if (angle >= 157.5 && angle < 202.5)
-            {
-                return PortAlignment.Left;
-            }
-            else if (angle >= 202.5 && angle < 247.5)
-            {
-                return PortAlignment.BottomLeft;
-            }
-            else if (angle >= 247.5 && angle < 292.5)
-            {
-                return PortAlignment.Bottom;
-            }
-            else if (angle >= 292.5 && angle < 337.5)
-            {
-                return PortAlignment.BottomRight;
-            }
-
-            return PortAlignment.Top;
         }
 
         /// <summary>
@@ -631,6 +595,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         public void CreateInterfacesLinks()
         {
             this.InterfacesMap.Clear();
+
             foreach (var interf in this.Interfaces)
             {
                 var sourcePortRowVM = this.PortsMap.Values.FirstOrDefault(port => port.ThingId == interf.SourceId);
@@ -644,13 +609,15 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
 
                 if (source != null && target != null)
                 {
-                    var link = new DiagramLink(source, target);
-                    link.Locked = true;
-                    link.Router = Routers.Orthogonal;
-                    link.PathGenerator = PathGenerators.Smooth;
-                    link.SourceMarker = LinkMarker.Square;
-                    link.TargetMarker = LinkMarker.Arrow;
-                    link.HasComments = interf.HasComment();
+                    var link = new DiagramLink(source, target)
+                    {
+                        Locked = true,
+                        Router = Routers.Orthogonal,
+                        PathGenerator = PathGenerators.Smooth,
+                        SourceMarker = LinkMarker.Square,
+                        TargetMarker = LinkMarker.Arrow,
+                        HasComments = interf.HasComment()
+                    };
 
                     if (!this.InterfacesMap.Keys.Any(x => x.TargetPort == link.TargetPort && x.SourcePort == link.SourcePort))
                     {
@@ -676,7 +643,8 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
                 node.HasComments = hasComments;
                 return true;
             }
-            else if (updatedObject is PortRowViewModel portRowViewModel && this.allPorts.Contains(portRowViewModel))
+
+            if (updatedObject is PortRowViewModel portRowViewModel && this.allPorts.Contains(portRowViewModel))
             {
                 var indexOfPort = this.allPorts.IndexOf(portRowViewModel);
                 var keyValuePair = this.PortsMap.First(x => x.Value == portRowViewModel);
@@ -687,7 +655,8 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
                 port.HasComments = hasComments;
                 return true;
             }
-            else if (updatedObject is InterfaceRowViewModel interfaceRowViewModel && this.Interfaces.Contains(interfaceRowViewModel))
+
+            if (updatedObject is InterfaceRowViewModel interfaceRowViewModel && this.Interfaces.Contains(interfaceRowViewModel))
             {
                 var indexOfInterface = this.Interfaces.IndexOf(interfaceRowViewModel);
                 var keyValuePair = this.InterfacesMap.First(x => x.Value == interfaceRowViewModel);
@@ -700,6 +669,152 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
             }
 
             return false;
+        }
+
+        /// <summary>
+        ///     The <see cref="IDiagrammingConfigurationPopupViewModel" />
+        /// </summary>
+        public IDiagrammingConfigurationPopupViewModel DiagrammingConfigurationPopupViewModel { get; private set; }
+
+        /// <summary>
+        ///     The <see cref="IDiagrammingConfigurationLoadingPopupViewModel" />
+        /// </summary>
+        public IDiagrammingConfigurationLoadingPopupViewModel DiagrammingConfigurationLoadingPopupViewModel { get; private set; }
+
+        /// <summary>
+        ///     The <see cref="IErrorMessageViewModel" />
+        /// </summary>
+        public IErrorMessageViewModel ErrorMessageViewModel { get; }
+
+        /// <summary>
+        ///     Value indicating the user is currently saving the diagramming configuration
+        /// </summary>
+        public bool IsOnSavingMode
+        {
+            get => this.isOnSavingMode;
+            set => this.RaiseAndSetIfChanged(ref this.isOnSavingMode, value);
+        }
+
+        /// <summary>
+        ///     Value indicating the user is currently loading the diagramming configuration
+        /// </summary>
+        public bool IsOnLoadingMode
+        {
+            get => this.isOnLoadingMode;
+            set => this.RaiseAndSetIfChanged(ref this.isOnLoadingMode, value);
+        }
+
+        /// <summary>
+        ///     Opens the <see cref="DiagrammingConfigurationPopup" />
+        /// </summary>
+        public void OpenSavingPopup()
+        {
+            this.ErrorMessageViewModel.Errors.Clear();
+            this.IsOnSavingMode = true;
+        }
+
+        /// <summary>
+        ///     Opens the <see cref="DiagrammingConfigurationLoadingPopup" />
+        /// </summary>
+        public async void OpenLoadingConfigurationPopup()
+        {
+            this.DiagrammingConfigurationLoadingPopupViewModel.ConfigurationsName = await this.diagrammingConfigurationService.LoadDiagramLayoutConfigurationNames(this.ProjectId, this.ReviewTaskId);
+            this.IsOnLoadingMode = true;
+        }
+
+        /// <summary>
+        ///     Saves current diagram layout
+        /// </summary>
+        public async Task SaveCurrentDiagramLayout()
+        {
+            var layoutInformationDtos = this.ProductsMap.Keys.Select(x => new DiagramLayoutInformationDto { ThingId = x.ThingId, xPosition = x.Position.X, yPosition = x.Position.Y });
+            var response = await this.diagrammingConfigurationService.SaveDiagramLayout(this.ProjectId, this.ReviewTaskId, this.DiagrammingConfigurationPopupViewModel.ConfigurationName, layoutInformationDtos);
+
+            this.ErrorMessageViewModel.Errors.Clear();
+
+            if (!response.result)
+            {
+                this.ErrorMessageViewModel.HandleErrors(response.errors);
+            }
+
+            this.IsOnSavingMode = !response.result;
+        }
+
+        /// <summary>
+        ///     Load choosen diagram layout
+        /// </summary>
+        public async Task LoadDiagramLayout()
+        {
+            var response = await this.diagrammingConfigurationService.LoadDiagramLayoutConfiguration(this.ProjectId, this.ReviewTaskId, this.DiagrammingConfigurationLoadingPopupViewModel.SelectedConfiguration);
+
+            this.ProductsMap.Clear();
+            this.PortsMap.Clear();
+            this.InterfacesMap.Clear();
+
+            foreach (var diagrammingInformationDto in response)
+            {
+                var productRowView = this.allProducts.FirstOrDefault(x => x.ThingId == diagrammingInformationDto.ThingId);
+                var node = this.CreateNewNodeFromProduct(productRowView);
+                node.SetPosition(diagrammingInformationDto.xPosition, diagrammingInformationDto.yPosition);
+            }
+
+            this.CreateInterfacesLinks();
+
+            this.IsOnLoadingMode = false;
+        }
+
+        /// <summary>
+        ///     Gets the aproximate alignment of the port depending its position in the node
+        /// </summary>
+        /// <param name="indexOfPort">the index of the port</param>
+        /// <param name="totalPortsInNode"></param>
+        /// <returns>the aproximate alignment of the port</returns>
+        private static PortAlignment GetAproximateAlignment(int indexOfPort, int totalPortsInNode)
+        {
+            var increment = 360.0 / totalPortsInNode;
+            var angle = increment * indexOfPort;
+
+            if (angle is >= 0 and < 22.5 or >= 337.5 and < 360.0)
+            {
+                return PortAlignment.Right;
+            }
+
+            if (angle is >= 22.5 and < 67.5)
+            {
+                return PortAlignment.TopRight;
+            }
+
+            if (angle is >= 67.5 and < 112.5)
+            {
+                return PortAlignment.Top;
+            }
+
+            if (angle is >= 112.5 and < 157.5)
+            {
+                return PortAlignment.TopLeft;
+            }
+
+            if (angle is >= 157.5 and < 202.5)
+            {
+                return PortAlignment.Left;
+            }
+
+            if (angle is >= 202.5 and < 247.5)
+            {
+                return PortAlignment.BottomLeft;
+            }
+
+            if (angle is >= 247.5 and < 292.5)
+            {
+                return PortAlignment.Bottom;
+            }
+
+            if (angle is >= 292.5 and < 337.5)
+            {
+                return PortAlignment.BottomRight;
+            }
+
+            return PortAlignment.Top;
         }
 
         /// <summary>
@@ -782,83 +897,6 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
             });
 
             this.FilterViewModel.InitializeProperties(availableRowFilters);
-        }
-
-        /// <summary>
-        ///     The <see cref="IDiagrammingConfigurationPopupViewModel" />
-        /// </summary>
-        public IDiagrammingConfigurationPopupViewModel DiagrammingConfigurationPopupViewModel { get; private set; }
-
-        /// <summary>
-        ///     The <see cref="IDiagrammingConfigurationLoadingPopupViewModel" />
-        /// </summary>
-        public IDiagrammingConfigurationLoadingPopupViewModel DiagrammingConfigurationLoadingPopupViewModel { get; private set; }
-
-        /// <summary>
-        ///     Value indicating the user is currently saving the diagramming configuration
-        /// </summary>
-        public bool IsOnSavingMode
-        {
-            get => this.isOnSavingMode;
-            set => this.RaiseAndSetIfChanged(ref this.isOnSavingMode, value);
-        }
-
-        /// <summary>
-        ///     Value indicating the user is currently loading the diagramming configuration
-        /// </summary>
-        public bool IsOnLoadingMode
-        {
-            get => this.isOnLoadingMode;
-            set => this.RaiseAndSetIfChanged(ref this.isOnLoadingMode, value);
-        }
-
-        /// <summary>
-        ///     Opens the <see cref="DiagrammingConfigurationPopup" />
-        /// </summary>
-        public void OpenSavingPopup()
-        {
-            this.IsOnSavingMode = true;
-        }
-
-        /// <summary>
-        ///     Opens the <see cref="DiagrammingConfigurationLoadingPopup" />
-        /// </summary>
-        public async void OpenLoadingConfigurationPopup()
-        {
-            this.DiagrammingConfigurationLoadingPopupViewModel.ConfigurationsName = await this.diagrammingConfigurationService.LoadDiagramLayoutConfigurationNames(this.ProjectId, this.ReviewTaskId);
-            this.IsOnLoadingMode = true;
-        }
-
-        /// <summary>
-        ///     Saves current diagram layout
-        /// </summary>
-        public async Task SaveCurrentDiagramLayout()
-        {
-            var layoutInformationDtos = this.ProductsMap.Keys.Select(x => new DiagramLayoutInformationDto { ThingId = x.ThingId, xPosition = x.Position.X, yPosition = x.Position.Y });
-            var response = await this.diagrammingConfigurationService.SaveDiagramLayout(this.ProjectId, this.ReviewTaskId, this.DiagrammingConfigurationPopupViewModel.ConfigurationName, layoutInformationDtos);
-            this.IsOnSavingMode = !response;
-        }
-
-        /// <summary>
-        ///     Load choosen diagram layout
-        /// </summary>
-        public async Task LoadDiagramLayout()
-        {
-            var response = await this.diagrammingConfigurationService.LoadDiagramLayoutConfiguration(this.ProjectId, this.ReviewTaskId, this.DiagrammingConfigurationLoadingPopupViewModel.SelectedConfiguration);
-
-            this.ProductsMap.Clear();
-            this.PortsMap.Clear();
-            this.InterfacesMap.Clear();
-
-            foreach (var diagrammingInformationDto in response) 
-            {
-                var productRowView = allProducts.FirstOrDefault(x => x.ThingId == diagrammingInformationDto.ThingId);
-                var node = CreateNewNodeFromProduct(productRowView);
-                node.SetPosition(diagrammingInformationDto.xPosition, diagrammingInformationDto.yPosition);
-            }
-            this.CreateInterfacesLinks();
-
-            this.IsOnLoadingMode = false;
         }
     }
 }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ProductBreakdownStructureViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/ProductBreakdownStructureViewViewModel.cs
@@ -49,10 +49,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             var topElement = this.Things.OfType<Iteration>()
                 .SingleOrDefault()?.TopElement;

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementBreakdownStructureViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementBreakdownStructureViewViewModel.cs
@@ -27,6 +27,8 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel;
     using UI_DSM.Shared.Models;
 
+    using Participant = UI_DSM.Shared.Models.Participant;
+
     /// <summary>
     ///     View model for the <see cref="RequirementBreakdownStructureView" /> component
     /// </summary>
@@ -62,10 +64,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             var filteredThings = this.Things.OfType<RequirementsSpecification>()
                 .SelectMany(x => x.Requirement)

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToFunctionViewViewModel.cs
@@ -68,10 +68,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             var requirements = this.Things.OfType<RequirementsSpecification>()
                 .SelectMany(x => x.Requirement)

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToProductViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToProductViewViewModel.cs
@@ -77,10 +77,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             var requirements = this.Things.OfType<RequirementsSpecification>()
                 .SelectMany(x => x.Requirement)

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToRequirementViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/RequirementTraceabilityToRequirementViewViewModel.cs
@@ -59,10 +59,11 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         /// <param name="reviewTaskId">The <see cref="ReviewTask" /> id</param>
         /// <param name="prefilters">A collection of prefilters</param>
         /// <param name="additionnalColumnsVisibleAtStart">A collection of columns name that can be visible by default at start</param>
+        /// <param name="participant"></param>
         /// <returns>A <see cref="Task" /></returns>
-        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart)
+        public override async Task InitializeProperties(IEnumerable<Thing> things, Guid projectId, Guid reviewId, Guid reviewTaskId, List<string> prefilters, List<string> additionnalColumnsVisibleAtStart, Participant participant)
         {
-            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart);
+            await base.InitializeProperties(things, projectId, reviewId, reviewTaskId, prefilters, additionnalColumnsVisibleAtStart, participant);
 
             var requirements = this.Things.OfType<RequirementsSpecification>()
                 .SelectMany(x => x.Requirement)

--- a/UI_DSM.Serializer.Json/AutoGenDtoDeserializer/AccessRightDeserializer.cs
+++ b/UI_DSM.Serializer.Json/AutoGenDtoDeserializer/AccessRightDeserializer.cs
@@ -40,6 +40,7 @@ namespace UI_DSM.Serializer.Json
                 "DELETEREVIEWOBJECTIVE" => AccessRight.DeleteReviewObjective,
                 "ASSIGNTASK" => AccessRight.AssignTask,
                 "PROJECTMANAGEMENT" => AccessRight.ProjectManagement,
+                "CREATEDIAGRAMCONFIGURATION" => AccessRight.CreateDiagramConfiguration,
                 _ => throw new ArgumentException($"{value} is not a valid AccessRight", nameof(value))
             };
         }

--- a/UI_DSM.Server/Context/Configuration/UiDsmRoleConfiguration.cs
+++ b/UI_DSM.Server/Context/Configuration/UiDsmRoleConfiguration.cs
@@ -54,7 +54,8 @@ namespace UI_DSM.Server.Context.Configuration
                     AccessRight.CreateReviewObjective,
                     AccessRight.DeleteReviewObjective,
                     AccessRight.AssignTask,
-                    AccessRight.ProjectManagement
+                    AccessRight.ProjectManagement,
+                    AccessRight.CreateDiagramConfiguration
                 }
             }, new Role(new Guid(ReviewerRoleId))
             {

--- a/UI_DSM.Shared/Enumerator/AccessRight.cs
+++ b/UI_DSM.Shared/Enumerator/AccessRight.cs
@@ -57,6 +57,11 @@ namespace UI_DSM.Shared.Enumerator
         /// <summary>
         ///     This right provide the capability to manage participants and models inside a project
         /// </summary>
-        [Display(Name = "Manage Project")] ProjectManagement = 6
+        [Display(Name = "Manage Project")] ProjectManagement = 6,
+
+        /// <summary>
+        ///     This right provide the capability to save a diagram configuration
+        /// </summary>
+        [Display(Name = "Save Diagram Configuration")] CreateDiagramConfiguration = 7
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/UI-DSM/pulls) open
- [x] I have verified that I am following the UI-DSM [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/UI-DSM/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #219 #242 #243 

- Only Participant with a Role where the AccessRight CreateDiagramConfiguration is selected can create a diagram configuration
- Better handling errors when creating a Diagram
- When filtering rows/columns inside traceability tables, rows/columns are correctly removed now
- Code cleanup for InterfaceViewViewModel and PhysicalFlowView
<!-- Thanks for contributing to UI-DSM! -->