### PR TITLE
Save-load modified, delete configuration enabled :Fix #254 #255 #257

### DIFF
--- a/UI_DSM.Client.Tests/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationLoadingPopupTestFixture.cs
+++ b/UI_DSM.Client.Tests/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationLoadingPopupTestFixture.cs
@@ -26,15 +26,14 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.DiagrammingConfiguration
     using UI_DSM.Client.Tests.Helpers;
     using UI_DSM.Client.ViewModels.Components;
     using UI_DSM.Client.ViewModels.Components.NormalUser.DiagrammingConfiguration;
-    using UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview;
-    using UI_DSM.Shared.DTO.Common;
+
     using TestContext = Bunit.TestContext;
 
     [TestFixture]
     public class DiagrammingConfigurationLoadingPopupTestFixture
     {
         private TestContext context;
-        private IDiagrammingConfigurationLoadingPopupViewModel diagrammingConfigurationLoadingPopupViewModel;
+        private IDiagrammingConfigurationDeletionPopupViewModel diagrammingConfigurationDeletionPopupViewModel;
         private IErrorMessageViewModel errorMessageViewModel;
 
         [SetUp]
@@ -44,10 +43,10 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.DiagrammingConfiguration
             this.context.ConfigureDevExpressBlazor();
             this.errorMessageViewModel = new ErrorMessageViewModel();
 
-            this.diagrammingConfigurationLoadingPopupViewModel = new DiagrammingConfigurationLoadingPopupViewModel()
+            this.diagrammingConfigurationDeletionPopupViewModel = new DiagrammingConfigurationDeletionPopupViewModel()
             {
                 SelectedConfiguration = "",
-                OnValidSubmit = new EventCallbackFactory().Create(this, () => this.diagrammingConfigurationLoadingPopupViewModel.SelectedConfiguration = "")
+                OnValidSubmit = new EventCallbackFactory().Create(this, () => this.diagrammingConfigurationDeletionPopupViewModel.SelectedConfiguration = "")
             };
         }
 
@@ -62,27 +61,27 @@ namespace UI_DSM.Client.Tests.Components.NormalUser.DiagrammingConfiguration
         {
             try
             {
-                var renderer = this.context.RenderComponent<DiagrammingConfigurationLoadingPopup>(parameters =>
+                var renderer = this.context.RenderComponent<DiagrammingConfigurationDeletionPopup>(parameters =>
                 {
-                    parameters.Add(p => p.ViewModel, this.diagrammingConfigurationLoadingPopupViewModel);
+                    parameters.Add(p => p.ViewModel, this.diagrammingConfigurationDeletionPopupViewModel);
+                    parameters.AddCascadingValue(this.errorMessageViewModel);
                 });
 
                 var listBox = renderer.FindComponent<DxListBox<string, string>>();
-
 
                 Assert.That(listBox.Instance.Values, Is.Empty);
 
                 var configurationsName = new List<string>() { "config1", "config2" };
 
-                this.diagrammingConfigurationLoadingPopupViewModel.ConfigurationsName = configurationsName;
-                this.diagrammingConfigurationLoadingPopupViewModel.SelectedConfiguration = configurationsName.First();
+                this.diagrammingConfigurationDeletionPopupViewModel.ConfigurationsName = configurationsName;
+                this.diagrammingConfigurationDeletionPopupViewModel.SelectedConfiguration = configurationsName.First();
 
                 renderer.Render();
 
                 var dxButton = renderer.FindComponent<EditForm>();
                 await renderer.InvokeAsync(dxButton.Instance.OnValidSubmit.InvokeAsync);
 
-                Assert.That(this.diagrammingConfigurationLoadingPopupViewModel.SelectedConfiguration, Is.EqualTo(""));
+                Assert.That(this.diagrammingConfigurationDeletionPopupViewModel.SelectedConfiguration, Is.EqualTo(""));
             }
             catch
             {

--- a/UI_DSM.Client.Tests/Services/DiagrammingConfigurationService/DiagrammingConfigurationServiceTestFixture.cs
+++ b/UI_DSM.Client.Tests/Services/DiagrammingConfigurationService/DiagrammingConfigurationServiceTestFixture.cs
@@ -118,7 +118,11 @@ namespace UI_DSM.Client.Tests.Services.DiagrammingConfigurationService
             var request = this.httpMessageHandler.When(HttpMethod.Get, $"/Layout/{projectId}/{reviewTaskId}/{configurationName}/Load");
             request.Respond(_ => httpResponse);
 
-            Assert.That(async () => await this.service.LoadDiagramLayoutConfiguration(projectId, reviewTaskId, configurationName), Throws.Exception);
+            var diagramDto = await this.service.LoadDiagramLayoutConfiguration(projectId, reviewTaskId, configurationName);
+            Assert.That(diagramDto, Is.Null);
+
+            diagramDto=await this.service.LoadDiagramLayoutConfiguration(projectId, reviewTaskId, string.Empty);
+            Assert.That(diagramDto, Is.Null);
 
             httpResponse.StatusCode = HttpStatusCode.OK;
             
@@ -138,8 +142,34 @@ namespace UI_DSM.Client.Tests.Services.DiagrammingConfigurationService
                 }
             }));
 
-            var diagramDto = await this.service.LoadDiagramLayoutConfiguration(projectId, reviewTaskId, configurationName);
+            diagramDto = await this.service.LoadDiagramLayoutConfiguration(projectId, reviewTaskId, configurationName);
             Assert.That(diagramDto.Nodes, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task VerifyDeleteDiagram()
+        {
+            var projectId = Guid.NewGuid();
+            var reviewTaskId = Guid.NewGuid();
+            const string configurationName = "config1";
+
+            var httpResponse = new HttpResponseMessage();
+            httpResponse.StatusCode = HttpStatusCode.NotFound;
+            httpResponse.Content = new StringContent(this.jsonService.Serialize("Unauthorized"));
+
+            var request = this.httpMessageHandler.When(HttpMethod.Delete, $"/Layout/{projectId}/{reviewTaskId}/{configurationName}");
+            request.Respond(_ => httpResponse);
+
+            var deletion = await this.service.DeleteDiagramLayoutConfiguration(projectId, reviewTaskId, configurationName);
+            Assert.That(deletion.success, Is.False);
+
+            deletion = await this.service.DeleteDiagramLayoutConfiguration(projectId, reviewTaskId, string.Empty);
+            Assert.That(deletion.success, Is.False);
+
+            httpResponse.StatusCode = HttpStatusCode.OK;
+
+            deletion = await this.service.DeleteDiagramLayoutConfiguration(projectId, reviewTaskId, configurationName);
+            Assert.That(deletion.success, Is.True);
         }
     }
 }

--- a/UI_DSM.Client/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationDeletionPopup.razor
+++ b/UI_DSM.Client/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationDeletionPopup.razor
@@ -1,5 +1,5 @@
 ﻿<!--------------------------------------------------------------------------------------------------------
-// DiagrammingConfigurationLoadingPopup.razor
+// DiagrammingConfigurationDeletionPopup.razor
 // Copyright (c) 2022 RHEA System S.A.
 //
 // Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
@@ -9,17 +9,18 @@
 //
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
-@using UI_DSM.Shared.Models
-
 <DxFormLayout>
 	<DxFormLayoutItem Caption="Configurations :" ColSpanMd="12">
 		<DxListBox Data="@this.ViewModel.ConfigurationsName"
-				   @bind-Value="@this.ViewModel.SelectedConfiguration"
-				   SelectionMode="ListBoxSelectionMode.Single" />
+		           @bind-Value="@this.ViewModel.SelectedConfiguration"
+		           SelectionMode="ListBoxSelectionMode.Single" />
 	</DxFormLayoutItem>
+	<ErrorMessage/>
 </DxFormLayout>
 
 <div class="modal-footer m-top-10px">
-	<DxButton RenderStyle="ButtonRenderStyle.Primary" Text="Load" Click="@this.ViewModel.OnValidSubmit" Enabled="@(!(string.IsNullOrEmpty(this.ViewModel.SelectedConfiguration)))" />
+	<DxButton RenderStyle="ButtonRenderStyle.Danger" 
+	          Text="Delete"
+	          Click="@this.ViewModel.OnValidSubmit" Enabled="@(!(string.IsNullOrEmpty(this.ViewModel.SelectedConfiguration)))" />
 </div>
 

--- a/UI_DSM.Client/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationDeletionPopup.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationDeletionPopup.razor.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------
-// <copyright file="DiagrammingConfigurationLoadingPopup.razor.cs" company="RHEA System S.A.">
+// <copyright file="DiagrammingConfigurationDeletionPopup.razor.cs" company="RHEA System S.A.">
 //  Copyright (c) 2022 RHEA System S.A.
 // 
 //  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
@@ -15,17 +15,17 @@ namespace UI_DSM.Client.Components.NormalUser.DiagrammingConfiguration
 {
     using Microsoft.AspNetCore.Components;
 
-    using UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview;
+    using UI_DSM.Client.ViewModels.Components.NormalUser.DiagrammingConfiguration;
 
     /// <summary>
     ///     This component is used to load a diagramming configuration
     /// </summary>
-    public partial class DiagrammingConfigurationLoadingPopup
+    public partial class DiagrammingConfigurationDeletionPopup
     {
         /// <summary>
-        ///     The <see cref="DiagrammingConfigurationLoadingPopupViewModel" /> for the component
+        ///     The <see cref="DiagrammingConfigurationDeletionPopupViewModel" /> for the component
         /// </summary>
         [Parameter]
-        public IDiagrammingConfigurationLoadingPopupViewModel ViewModel { get; set; }
+        public IDiagrammingConfigurationDeletionPopupViewModel ViewModel { get; set; }
     }
 }

--- a/UI_DSM.Client/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationPopup.razor
+++ b/UI_DSM.Client/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationPopup.razor
@@ -10,7 +10,7 @@
 // The UI-DSM application is provided to the community under the Apache License 2.0.
 -------------------------------------------------------------------------------------------------------->
 <DxFormLayout>
-	<DxFormLayoutItem Caption="Configuration Name (Max. 5 configurations):" ColSpanMd="12">
+	<DxFormLayoutItem Caption="Configuration Name (Max. 20 configurations):" ColSpanMd="12">
 		<DxTextBox @bind-Text="@this.ViewModel.ConfigurationName" 
 		           BindValueMode="BindValueMode.OnInput"
 		           NullText="Enter the name of the configuration to save" />

--- a/UI_DSM.Client/Components/NormalUser/Views/PhysicalFlowView.razor
+++ b/UI_DSM.Client/Components/NormalUser/Views/PhysicalFlowView.razor
@@ -16,6 +16,15 @@
 @using Blazor.Diagrams.Components
 @inherits GenericBaseView<UI_DSM.Client.ViewModels.Components.NormalUser.Views.IInterfaceViewViewModel>
 
+<ConfirmCancelPopup ViewModel="@this.ViewModel.ConfirmCancelPopup" />
+<DxPopup CloseOnOutsideClick="false" HeaderText="Delete Configuration" @bind-Visible="@(this.ViewModel.IsOnDeletionMode)">
+	<Content>
+		<CascadingValue Value="this.ViewModel.ErrorMessageViewModel">
+			<DiagrammingConfigurationDeletionPopup ViewModel="@(this.ViewModel.DiagrammingConfigurationDeletionPopupViewModel)"/>
+		</CascadingValue>
+	</Content>
+</DxPopup>
+
 <DxPopup CloseOnOutsideClick="false" HeaderText="Save Configuration" @bind-Visible="@(this.ViewModel.IsOnSavingMode)">
 	<Content>
 		<CascadingValue Value="this.ViewModel.ErrorMessageViewModel">
@@ -24,30 +33,38 @@
 	</Content>
 </DxPopup>
 
-<DxPopup CloseOnOutsideClick="false" HeaderText="Load Configuration" @bind-Visible="@(this.ViewModel.IsOnLoadingMode)">
-	<Content>
-		<DiagrammingConfigurationLoadingPopup ViewModel="@(this.ViewModel.DiagrammingConfigurationLoadingPopupViewModel)"/>
-	</Content>
-</DxPopup>
 <LoadingComponent IsLoading="@(this.IsLoading)">
 	@if (this.ViewModel.Participant.IsAllowedTo(AccessRight.CreateDiagramConfiguration))
 	{
 		<AppButton Label="Save layout" Type="button" Variant="AppButton.VariantValue.Tertiary" Click="@(this.ViewModel.OpenSavingPopup)">
 			<FeatherSave Size="20" Color="currentColor" StrokeWidth="2"/> <span>Save</span>
 		</AppButton>
-	}
 
-	<AppButton Label="Load layout" Type="button" Variant="AppButton.VariantValue.Tertiary" Click="@(this.ViewModel.OpenLoadingConfigurationPopup)">
-		<FeatherUpload Size="20" Color="currentColor" StrokeWidth="2"/> <span>Load</span>
-	</AppButton>
+		<AppButton Label="Delete layout" Type="button" Variant="AppButton.VariantValue.Tertiary" Click="@(this.ViewModel.OpenDeletionComponent)">
+			<FeatherTrash2 Size="20" Color="currentColor" StrokeWidth="2"/> <span>Delete</span>
+		</AppButton>
+	}
+	
+	<button id="load-configuration-button" type="button" @onclick="this.ViewModel.OpenLoadingConfiguration">
+		<FeatherEye Size="20" Color="currentColor" StrokeWidth="2" /><span>@(string.IsNullOrEmpty(this.ViewModel.SelectedConfiguration)? "No configuration" : this.ViewModel.SelectedConfiguration)</span>
+	</button>
+	<DxDropDown @bind-IsOpen="@(this.ViewModel.IsOnLoadingMode)"
+	            Width="200"
+	            MaxHeight="500"
+	            PositionTarget="#load-configuration-button"
+	            PositionMode="DropDownPositionMode.Bottom"
+	            PreventCloseOnPositionTargetClick="true">
+		<BodyTemplate>
+			<DxListBox DataAsync="@this.ViewModel.GetAvailableConfigurations" 
+			           @bind-Value="@(this.ViewModel.SelectedConfiguration)"/>
+		</BodyTemplate>
+	</DxDropDown>
 
 	<Filter ViewModel="this.ViewModel.FilterViewModel" Id="row">
 		<FeatherFilter Size="20" Color="currentColor" StrokeWidth="2"/> <span>Filter</span>
 	</Filter>
 	<CascadingValue Value="this.Diagram">
 		<div id="diagram-parent" @ref="this.DiagramReference">
-
-
 			<DiagramCanvas/>
 			<DiagramLegendWidget/>
 		</div>

--- a/UI_DSM.Client/Components/NormalUser/Views/PhysicalFlowView.razor.cs
+++ b/UI_DSM.Client/Components/NormalUser/Views/PhysicalFlowView.razor.cs
@@ -97,6 +97,7 @@ namespace UI_DSM.Client.Components.NormalUser.Views
 
             this.ViewModel = interfaceView.ViewModel;
             this.ViewModel.InitializeDiagram();
+            this.ViewModel.SelectedConfiguration = string.Empty;
             this.RefreshDiagram();
             await this.HasChanged();
 
@@ -320,11 +321,20 @@ namespace UI_DSM.Client.Components.NormalUser.Views
                 this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnSavingMode)
                     .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
 
+                this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnDeletionMode)
+                    .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+
+                this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.ConfirmCancelPopup.IsVisible)
+                    .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
+
                 this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnLoadingMode)
                     .Subscribe(_ => this.InvokeAsync(this.StateHasChanged)));
 
                 this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.IsOnLoadingMode)
-                    .Subscribe(async x => await this.OnIsOnLoadingModeChanged(x)));
+                    .Subscribe(async x => await this.InvokeAsync(() => this.OnIsOnLoadingModeChanged(x))));
+
+                this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.SelectedConfiguration)
+                    .Subscribe(async _ => await this.ViewModel.LoadDiagramLayout()));
 
                 this.disposables.Add(this.WhenAnyValue(x => x.ViewModel.FilterViewModel.IsFilterVisible)
                     .Where(x => !x)
@@ -341,8 +351,8 @@ namespace UI_DSM.Client.Components.NormalUser.Views
         ///     Handle the change of the <see cref="IsOnLoadingMode" /> variable
         /// </summary>
         /// <param name="value">The IsOnLoadingMode</param>
-        /// <returns>A <see cref="Task" /></returns>
-        private async Task OnIsOnLoadingModeChanged(bool value)
+        /// <returns>A <see cref="Task"/></returns>
+        private Task OnIsOnLoadingModeChanged(bool value)
         {
             if (!value && this.ViewModel.HasLoadedConfiguration)
             {
@@ -351,7 +361,7 @@ namespace UI_DSM.Client.Components.NormalUser.Views
                 this.ViewModel.HasLoadedConfiguration = false;
             }
 
-            await this.InvokeAsync(this.StateHasChanged);
+            return this.InvokeAsync(this.StateHasChanged);
         }
 
         /// <summary>

--- a/UI_DSM.Client/Pages/NormalUser/SearchPage/SearchPage.razor
+++ b/UI_DSM.Client/Pages/NormalUser/SearchPage/SearchPage.razor
@@ -28,30 +28,20 @@
 <h3>Results for: @this.Keyword</h3>
 
 <LoadingComponent IsLoading="@this.isLoading">
-	@foreach (var objectGroup in this.searchResults.GroupBy(x => x.ObjectKind)
-		.ToDictionary(g => g.Key, g => g.ToList()))
+	@foreach (var locationGroup in this.searchResults.GroupBy(x => x.Location)
+		.ToDictionary(g => g.Key ?? "UI-DSM", g => g.ToList()))
 	{
-		<AppAccordion PanelOpen="false" Label="@objectGroup.Key">
+		<AppAccordion PanelOpen="false" Label="@locationGroup.Key">
 			
-			@foreach (var locationGroup in objectGroup.Value.GroupBy(x => x.Location)
-				.ToDictionary(g => g.Key ?? string.Empty, g => g.ToList()))
+			@foreach (var objectKindGroup in locationGroup.Value.GroupBy(x => x.ObjectKind)
+				.ToDictionary(g => g.Key, g => g.ToList()))
 			{
-				if (!string.IsNullOrEmpty(locationGroup.Key))
-				{
-					<AppAccordion PanelOpen="false" Label="@locationGroup.Key" Variant="AppAccordion.VariantValue.Medium">
-						@foreach (var result in locationGroup.Value)
-						{
-							<SearchResultCard SearchResult="@result" OnClick="this.ViewModel.NavigateTo"/>
-						}
-					</AppAccordion>
-				}
-				else
-				{
-					@foreach (var result in locationGroup.Value)
+				<AppAccordion PanelOpen="false" Label="@objectKindGroup.Key" Variant="AppAccordion.VariantValue.Medium">
+					@foreach (var result in objectKindGroup.Value)
 					{
 						<SearchResultCard SearchResult="@result" OnClick="this.ViewModel.NavigateTo"/>
 					}
-				}
+				</AppAccordion>
 			}
 		</AppAccordion>
 	}

--- a/UI_DSM.Client/Services/DiagrammingConfigurationService/DiagrammingConfigurationService.cs
+++ b/UI_DSM.Client/Services/DiagrammingConfigurationService/DiagrammingConfigurationService.cs
@@ -13,8 +13,10 @@
 
 namespace UI_DSM.Client.Services.DiagrammingConfigurationService
 {
-    using Microsoft.AspNetCore.Components;
     using System.Text;
+
+    using Microsoft.AspNetCore.Components;
+
     using UI_DSM.Client.Services.JsonService;
     using UI_DSM.Shared.DTO.Common;
     using UI_DSM.Shared.Models;
@@ -40,7 +42,7 @@ namespace UI_DSM.Client.Services.DiagrammingConfigurationService
         /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" /></param>
         /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" /></param>
         /// <param name="configurationName">The name of the configuration</param>
-        /// <param name="diagram">The <see cref="DiagramDto"/></param>
+        /// <param name="diagram">The <see cref="DiagramDto" /></param>
         /// <returns>A <see cref="Task" /> </returns>
         public async Task<(bool result, List<string> errors)> SaveDiagramLayout(Guid projectId, Guid reviewTaskId, string configurationName, DiagramDto diagram)
         {
@@ -77,7 +79,7 @@ namespace UI_DSM.Client.Services.DiagrammingConfigurationService
             {
                 throw new HttpRequestException(response.ReasonPhrase);
             }
-            
+
             var content = this.jsonService.Deserialize<List<string>>(await response.Content.ReadAsStreamAsync());
             return content;
         }
@@ -91,15 +93,45 @@ namespace UI_DSM.Client.Services.DiagrammingConfigurationService
         /// <returns>A <see cref="Task" /> with the <see cref="DiagramDto" /></returns>
         public async Task<DiagramDto> LoadDiagramLayoutConfiguration(Guid projectId, Guid reviewTaskId, string configurationName)
         {
+            if (string.IsNullOrEmpty(configurationName))
+            {
+                return null;
+            }
+
             var response = await this.HttpClient.GetAsync($"{this.MainRoute}/{projectId}/{reviewTaskId}/{configurationName}/Load");
 
             if (!response.IsSuccessStatusCode)
             {
-                throw new HttpRequestException(response.ReasonPhrase);
+                return null;
             }
-            
+
             var content = this.jsonService.Deserialize<DiagramDto>(await response.Content.ReadAsStreamAsync());
             return content;
+        }
+
+        /// <summary>
+        ///     Deletes a diagram configuration
+        /// </summary>
+        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" /></param>
+        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" /></param>
+        /// <param name="configurationName">The name of the selected configuration</param>
+        /// <returns>A <see cref="Task" /> with the result of the deletion</returns>
+        public async Task<(bool success, string error)> DeleteDiagramLayoutConfiguration(Guid projectId, Guid reviewTaskId, string configurationName)
+        {
+            if (string.IsNullOrEmpty(configurationName))
+            {
+                return (false, "Empty configuration name");
+            }
+
+            var response = await this.HttpClient.DeleteAsync($"{this.MainRoute}/{projectId}/{reviewTaskId}/{configurationName}");
+
+            if (response.IsSuccessStatusCode)
+            {
+                return (true, string.Empty);
+            }
+
+            var content = this.jsonService.Deserialize<string>(await response.Content.ReadAsStreamAsync());
+            return (false, content);
         }
     }
 }

--- a/UI_DSM.Client/Services/DiagrammingConfigurationService/IDiagrammingConfigurationService.cs
+++ b/UI_DSM.Client/Services/DiagrammingConfigurationService/IDiagrammingConfigurationService.cs
@@ -47,5 +47,14 @@ namespace UI_DSM.Client.Services.DiagrammingConfigurationService
         /// <param name="configurationName">The name of the selected configuration</param>
         /// <returns>A <see cref="Task" /> with the <see cref="DiagramDto" /></returns>
         Task<DiagramDto> LoadDiagramLayoutConfiguration(Guid projectId, Guid reviewTaskId, string configurationName);
+
+        /// <summary>
+        ///     Deletes a diagram configuration
+        /// </summary>
+        /// <param name="projectId">The <see cref="Entity.Id" /> of the <see cref="Project" /></param>
+        /// <param name="reviewTaskId">The <see cref="Entity.Id" /> of the <see cref="ReviewTask" /></param>
+        /// <param name="configurationName">The name of the selected configuration</param>
+        /// <returns>A <see cref="Task" /> with the result of the deletion</returns>
+        Task<(bool success, string error)> DeleteDiagramLayoutConfiguration(Guid projectId, Guid reviewTaskId, string configurationName);
     }
 }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationDeletionPopupViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/DiagrammingConfiguration/DiagrammingConfigurationDeletionPopupViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------
-// <copyright file="DiagrammingConfigurationLoadingPopupViewModel.cs" company="RHEA System S.A.">
+// <copyright file="DiagrammingConfigurationDeletionPopupViewModel.cs" company="RHEA System S.A.">
 //  Copyright (c) 2022 RHEA System S.A.
 // 
 //  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
@@ -11,19 +11,16 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------
 
-namespace UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview
+namespace UI_DSM.Client.ViewModels.Components.NormalUser.DiagrammingConfiguration
 {
     using Microsoft.AspNetCore.Components;
 
-    using UI_DSM.Client.Components.NormalUser.ProjectReview;
-    using UI_DSM.Client.Enumerator;
-    using UI_DSM.Client.Services.Administration.ProjectService;
-    using UI_DSM.Shared.Models;
+    using UI_DSM.Client.Components.NormalUser.DiagrammingConfiguration;
 
     /// <summary>
-    ///     View model for the <see cref="DiagrammingConfigurationLoadingPopup" /> component
+    ///     View model for the <see cref="DiagrammingConfigurationDeletionPopup" /> component
     /// </summary>
-    public class DiagrammingConfigurationLoadingPopupViewModel : IDiagrammingConfigurationLoadingPopupViewModel
+    public class DiagrammingConfigurationDeletionPopupViewModel : IDiagrammingConfigurationDeletionPopupViewModel
     {
         /// <summary>
         ///     The list of available configurations
@@ -39,6 +36,5 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview
         ///     The <see cref="EventCallback" /> to call for data submit
         /// </summary>
         public EventCallback OnValidSubmit { get; set; }
-
     }
 }

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/DiagrammingConfiguration/IDiagrammingConfigurationDeletionPopupViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/DiagrammingConfiguration/IDiagrammingConfigurationDeletionPopupViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------
-// <copyright file="IDiagrammingConfigurationLoadingPopupViewModel.cs" company="RHEA System S.A.">
+// <copyright file="IDiagrammingConfigurationDeletionPopupViewModel.cs" company="RHEA System S.A.">
 //  Copyright (c) 2022 RHEA System S.A.
 // 
 //  Author: Antoine Théate, Sam Gerené, Alex Vorobiev, Alexander van Delft, Martin Risseeuw, Nabil Abbar
@@ -11,17 +11,14 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------
 
-namespace UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview
+namespace UI_DSM.Client.ViewModels.Components.NormalUser.DiagrammingConfiguration
 {
     using Microsoft.AspNetCore.Components;
 
-    using UI_DSM.Client.Enumerator;
-    using UI_DSM.Shared.Models;
-
     /// <summary>
-    ///     Interface definition for <see cref="DiagrammingConfigurationLoadingPopupViewModel" />
+    ///     Interface definition for <see cref="DiagrammingConfigurationDeletionPopupViewModel" />
     /// </summary>
-    public interface IDiagrammingConfigurationLoadingPopupViewModel
+    public interface IDiagrammingConfigurationDeletionPopupViewModel
     {
         /// <summary>
         ///     The list of available configurations

--- a/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IInterfaceViewViewModel.cs
+++ b/UI_DSM.Client/ViewModels/Components/NormalUser/Views/IInterfaceViewViewModel.cs
@@ -23,6 +23,7 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
     using UI_DSM.Client.Model;
     using UI_DSM.Client.ViewModels.App.ConnectionVisibilitySelector;
     using UI_DSM.Client.ViewModels.App.Filter;
+    using UI_DSM.Client.ViewModels.Components.NormalUser.DiagrammingConfiguration;
     using UI_DSM.Client.ViewModels.Components.NormalUser.ProjectReview;
     using UI_DSM.Client.ViewModels.Components.NormalUser.Views.RowViewModel;
 
@@ -107,9 +108,9 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         IDiagrammingConfigurationPopupViewModel DiagrammingConfigurationPopupViewModel { get; }
 
         /// <summary>
-        ///     The <see cref="IDiagrammingConfigurationLoadingPopupViewModel" />
+        ///     The <see cref="IDiagrammingConfigurationDeletionPopupViewModel" />
         /// </summary>
-        IDiagrammingConfigurationLoadingPopupViewModel DiagrammingConfigurationLoadingPopupViewModel { get; }
+        IDiagrammingConfigurationDeletionPopupViewModel DiagrammingConfigurationDeletionPopupViewModel { get; }
 
         /// <summary>
         ///     The <see cref="IErrorMessageViewModel" />
@@ -120,6 +121,21 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         ///     Indicates that a configuration has been loaded
         /// </summary>
         bool HasLoadedConfiguration { get; set; }
+
+        /// <summary>
+        ///     The current selected configuration
+        /// </summary>
+        string SelectedConfiguration { get; set; }
+
+        /// <summary>
+        ///     The <see cref="IConfirmCancelPopupViewModel" />
+        /// </summary>
+        IConfirmCancelPopupViewModel ConfirmCancelPopup { get; }
+
+        /// <summary>
+        ///     Value indicating if the current state is a deletion state
+        /// </summary>
+        bool IsOnDeletionMode { get; set; }
 
         /// <summary>
         ///     Filters current rows
@@ -232,14 +248,33 @@ namespace UI_DSM.Client.ViewModels.Components.NormalUser.Views
         void OpenSavingPopup();
 
         /// <summary>
-        ///     Opens the <see cref="DiagrammingConfigurationLoadingPopup" />
+        ///     Display to the user all available configuration to load
         /// </summary>
-        void OpenLoadingConfigurationPopup();
+        void OpenLoadingConfiguration();
 
         /// <summary>
         ///     Filters current rows for the diagram
         /// </summary>
         /// <param name="selectedFilters">The selected filters</param>
         void FilterRowsForDiagram(Dictionary<ClassKind, List<FilterRow>> selectedFilters);
+
+        /// <summary>
+        ///     Gets all available configuration
+        /// </summary>
+        /// <param name="token">The <see cref="CancellationToken" /></param>
+        /// <returns>A collection of <see cref="string" /></returns>
+        Task<IEnumerable<string>> GetAvailableConfigurations(CancellationToken token);
+
+        /// <summary>
+        ///     Load choosen diagram layout
+        /// </summary>
+        /// <returns>A <see cref="Task" /></returns>
+        Task LoadDiagramLayout();
+
+        /// <summary>
+        /// Opens the deletion component
+        /// </summary>
+        /// <returns>A <see cref="Task"/></returns>
+        Task OpenDeletionComponent();
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/UI-DSM/pulls) open
- [x] I have verified that I am following the UI-DSM [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/UI-DSM/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
Fix #254 #255 #257

- Can save up to 20configurations
- Loading a configuration is done by a dropdown
- Can delete a configuration
- On search result, location and objectKind grouping has been inverted
<!-- Thanks for contributing to UI-DSM! -->